### PR TITLE
Track B: prepare Supabase data layer and membership intake

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,15 @@
 # Postgres connection (Supabase pooler URL)
 DATABASE_URL=
 
+# Supabase browser client configuration (publishable, not secret)
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_PUBLISHABLE_KEY=
+
+# Server-only email provider credential
+RESEND_API_KEY=
+RESEND_FROM_EMAIL=
+MEMBERSHIP_NOTIFICATION_EMAIL=
+
 # Auth.js/NextAuth session secret (replaced by Supabase Auth at cutover)
 AUTH_SECRET=
 

--- a/app/(pages)/Home/HomeComponents/EventCard.tsx
+++ b/app/(pages)/Home/HomeComponents/EventCard.tsx
@@ -10,7 +10,7 @@ const EventCard: React.FC<CardProp> = ({ Card }) => {
     <div className="flex flex-col items-center border-b-[3px] border-[#efb631] pt-5 pb-4">
       <div className="w-[90%] md:w-full h-[200px]">
         <img
-          src={Card.imageURL === "" ? `./ctfWinner.jpg` : Card.imageURL}
+          src="/ctfWinner.jpg"
           alt="event"
           className="w-full h-full object-cover"
         />
@@ -40,7 +40,7 @@ const EventCard: React.FC<CardProp> = ({ Card }) => {
               />
             </svg>
             <span className="flex font-bold text-base line-clamp-1 text-black/90">
-              {Card.location}Mlimani City
+              {Card.location ?? "Venue to be confirmed"}
             </span>
           </div>
           <div className="flex gap-4">
@@ -60,7 +60,7 @@ const EventCard: React.FC<CardProp> = ({ Card }) => {
                 />
               </svg>
               <span className="flex font-bold text-base line-clamp-1 text-black/90">
-                {Card.date.slice(0, 10)}
+                {Card.startsAt.slice(0, 10)}
               </span>
             </div>
             <div className="flex gap-2 items-center">
@@ -79,7 +79,7 @@ const EventCard: React.FC<CardProp> = ({ Card }) => {
                 />
               </svg>
               <span className="flex font-bold text-base line-clamp-1 text-black/90">
-                {Card.date.slice(11, 16)}
+                {Card.startsAt.slice(11, 16)}
               </span>
             </div>
           </div>

--- a/app/(pages)/Membership/actions.ts
+++ b/app/(pages)/Membership/actions.ts
@@ -1,0 +1,120 @@
+"use server";
+
+import { createHash } from "node:crypto";
+import { headers } from "next/headers";
+import { sql } from "drizzle-orm";
+import { Resend } from "resend";
+import { db } from "@/app/db";
+import { members, membershipRateLimits } from "@/app/db/schema";
+
+export type MembershipActionState = {
+  status: "idle" | "success" | "error";
+  message: string;
+};
+
+export const initialMembershipActionState: MembershipActionState = {
+  status: "idle",
+  message: "",
+};
+
+class RateLimitError extends Error {}
+
+function field(formData: FormData, name: string, maxLength: number): string {
+  const value = formData.get(name);
+  return typeof value === "string" ? value.trim().slice(0, maxLength) : "";
+}
+
+function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (character) => {
+    const entities: Record<string, string> = {
+      "&": "&amp;",
+      "<": "&lt;",
+      ">": "&gt;",
+      '"': "&quot;",
+      "'": "&#039;",
+    };
+    return entities[character];
+  });
+}
+
+export async function submitMembershipApplication(
+  _previousState: MembershipActionState,
+  formData: FormData
+): Promise<MembershipActionState> {
+  if (field(formData, "website", 200)) {
+    return { status: "success", message: "Application received." };
+  }
+
+  const firstName = field(formData, "firstName", 100);
+  const lastName = field(formData, "lastName", 100);
+  const email = field(formData, "email", 254).toLowerCase();
+  const clubInterest = field(formData, "clubInterest", 120);
+  const message = field(formData, "message", 1000);
+
+  if (!firstName || !lastName || !clubInterest || !/^\S+@\S+\.\S+$/.test(email)) {
+    return { status: "error", message: "Check your name, email, and club interest." };
+  }
+
+  const requestHeaders = await headers();
+  const forwardedFor = requestHeaders.get("x-forwarded-for")?.split(",")[0]?.trim();
+  const address = forwardedFor || requestHeaders.get("x-real-ip") || "unknown";
+  const keyHash = createHash("sha256").update(address).digest("hex");
+
+  try {
+    const created = await db.transaction(async (transaction) => {
+      const [limit] = await transaction
+        .insert(membershipRateLimits)
+        .values({ keyHash })
+        .onConflictDoUpdate({
+          target: membershipRateLimits.keyHash,
+          set: {
+            attempts: sql`case when ${membershipRateLimits.windowStartedAt} < now() - interval '1 hour' then 1 else ${membershipRateLimits.attempts} + 1 end`,
+            windowStartedAt: sql`case when ${membershipRateLimits.windowStartedAt} < now() - interval '1 hour' then now() else ${membershipRateLimits.windowStartedAt} end`,
+          },
+        })
+        .returning({ attempts: membershipRateLimits.attempts });
+
+      if (limit.attempts > 5) {
+        throw new RateLimitError();
+      }
+
+      const [member] = await transaction
+        .insert(members)
+        .values({ firstName, lastName, email, clubInterest, message: message || null })
+        .onConflictDoNothing({ target: members.email })
+        .returning({ id: members.id });
+
+      return member;
+    });
+
+    if (!created) {
+      return { status: "success", message: "We already have an application for this email." };
+    }
+
+    const from = process.env.RESEND_FROM_EMAIL;
+    const to = process.env.MEMBERSHIP_NOTIFICATION_EMAIL;
+    if (process.env.RESEND_API_KEY && from && to) {
+      const resend = new Resend(process.env.RESEND_API_KEY);
+      const { error } = await resend.emails.send({
+        from,
+        to: [to],
+        subject: `New UISS membership application from ${firstName} ${lastName}`,
+        html: `<p><strong>Name:</strong> ${escapeHtml(firstName)} ${escapeHtml(lastName)}</p>
+          <p><strong>Email:</strong> ${escapeHtml(email)}</p>
+          <p><strong>Club interest:</strong> ${escapeHtml(clubInterest)}</p>
+          <p><strong>Message:</strong> ${escapeHtml(message || "None")}</p>`,
+      });
+      if (error) {
+        console.error("Membership notification failed", error.message);
+      }
+    }
+
+    return { status: "success", message: "Application received. The UISS team reviews applications weekly." };
+  } catch (error) {
+    if (error instanceof RateLimitError) {
+      return { status: "error", message: "Too many attempts. Try again in an hour." };
+    }
+    console.error("Membership application failed", error);
+    return { status: "error", message: "We could not save your application. Try again." };
+  }
+}

--- a/app/admin/AdminPages/Clubs/components/eventList.tsx
+++ b/app/admin/AdminPages/Clubs/components/eventList.tsx
@@ -22,8 +22,8 @@ const EventList: React.FC<props> = async ({ id }) => {
             <UpcomingEventsCard
               key={event.id}
               title={event.title}
-              date={event.date}
-              location={event.location}
+              date={event.startsAt}
+              location={event.location ?? "Venue to be confirmed"}
             />
           );
         })

--- a/app/admin/types.ts
+++ b/app/admin/types.ts
@@ -12,12 +12,12 @@ export interface IPosition {
 
 export interface IEvents {
   id: number;
-  clubID: number;
+  clubId: number | null;
   title: string;
   description: string;
-  date: string;
-  location: string;
-  imageURL: string;
+  startsAt: string;
+  endsAt: string | null;
+  location: string | null;
   addedOn: Date;
 }
 
@@ -38,7 +38,6 @@ export interface IClubDetail {
 
 export interface INewClub {
   id: number | null;
-  visionMissionID: number | null;
   title: string | null;
   description: string | null;
   introVidId: string | null;

--- a/app/api/clubs/[id]/route.tsx
+++ b/app/api/clubs/[id]/route.tsx
@@ -1,7 +1,7 @@
 import { requireAdmin } from "@/lib/requireAdmin";
 
 import { db } from '@/app/db';
-import { clubs, userClub, visionMission } from '@/app/db/schema';
+import { clubs } from '@/app/db/schema';
 import { eq } from 'drizzle-orm';
 import { NextRequest, NextResponse } from 'next/server';
 
@@ -22,13 +22,11 @@ export async function GET(
         clubId: clubs.id,
         clubName: clubs.title,
         clubDescription: clubs.description,
-        vision: visionMission.vision,
-        mission: visionMission.mission,
-        visiondescription: visionMission.description,
+        vision: clubs.vision,
+        mission: clubs.mission,
+        visiondescription: clubs.description,
       })
       .from(clubs)
-      .leftJoin(userClub, eq(userClub.clubID, clubs.id))
-      .leftJoin(visionMission, eq(clubs.visionMissionID, visionMission.id))
       .where(eq(clubs.id, clubId));
 
     if (clubDetails.length === 0) {
@@ -70,9 +68,27 @@ export async function PATCH(
     }
 
     const body = await request.json();
+    const changes = {
+      title: body.title,
+      summary: body.summary,
+      description: body.description,
+      vision: body.vision,
+      mission: body.mission,
+      disciplines: body.disciplines,
+      skillLevels: body.skillLevels,
+      schedule: body.schedule,
+      location: body.location,
+      eligibility: body.eligibility,
+      status: body.status,
+      introVidId: body.introVidId,
+      updatedAt: new Date(),
+    };
+    const values = Object.fromEntries(
+      Object.entries(changes).filter(([, value]) => value !== undefined)
+    );
     const updatedClub = await db
       .update(clubs)
-      .set(body)
+      .set(values)
       .where(eq(clubs.id, clubId))
       .returning();
 

--- a/app/api/clubs/route.tsx
+++ b/app/api/clubs/route.tsx
@@ -2,8 +2,8 @@ import { requireAdmin } from "@/lib/requireAdmin";
 
 import { INewClub } from "@/app/admin/types";
 import { db } from "@/app/db";
-import { clubs, visionMission } from "@/app/db/schema";
-import { eq } from "drizzle-orm";
+import { clubs } from "@/app/db/schema";
+import { slugify } from "@/lib/slugify";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET() {
@@ -14,12 +14,11 @@ export async function GET() {
         title: clubs.title,
         description: clubs.description,
         introVidId: clubs.introVidId,
-        vision: visionMission.vision,
-        mission: visionMission.mission,
-        visiondescription: visionMission.description,
+        vision: clubs.vision,
+        mission: clubs.mission,
+        visiondescription: clubs.description,
       })
       .from(clubs)
-      .leftJoin(visionMission, eq(clubs.visionMissionID, visionMission.id))
       .orderBy(clubs.id);
 
     if (allClubs.length === 0) {
@@ -44,29 +43,29 @@ export async function POST(request: NextRequest) {
 
   const body = await request.json();
   try {
-    let newClub: INewClub[] = []
-    await db.transaction(async (trx) => {
-      const [vision] = await trx
-        .insert(visionMission)
-        .values({
-          vision: body.vision,
-          mission: body.mission,
-          description: body.missiondescription,
-        })
-        .returning();
+    const title = String(body.title ?? "").trim();
+    if (!title) {
+      return NextResponse.json({ message: "Title is required" }, { status: 400 });
+    }
 
-      newClub = await trx
-        .insert(clubs)
-        .values({
-          title: body.title,
-          description: body.description,
-          visionMissionID: vision.id,
-          introVidId: body.introVidId,
-        })
-        .onConflictDoNothing()
-        .returning()
-        
-    });
+    const newClub: INewClub[] = await db
+      .insert(clubs)
+      .values({
+        slug: slugify(String(body.slug || title)),
+        title,
+        summary: String(body.summary ?? body.description ?? ""),
+        description: body.description,
+        vision: body.vision,
+        mission: body.mission,
+        introVidId: body.introVidId,
+      })
+      .onConflictDoNothing()
+      .returning({
+        id: clubs.id,
+        title: clubs.title,
+        description: clubs.description,
+        introVidId: clubs.introVidId,
+      });
 
     return NextResponse.json(newClub, { status: 201 });
   } catch (e) {

--- a/app/api/events/[id]/route.tsx
+++ b/app/api/events/[id]/route.tsx
@@ -2,6 +2,7 @@ import { requireAdmin } from "@/lib/requireAdmin";
 
 import { db } from "@/app/db";
 import { events } from "@/app/db/schema";
+import { slugify } from "@/lib/slugify";
 import { eq } from "drizzle-orm";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -22,7 +23,7 @@ export async function GET(
     const eventsResults = await db
       .select()
       .from(events)
-      .where(eq(events.clubID, clubId));
+      .where(eq(events.clubId, clubId));
     return NextResponse.json(eventsResults, { status: 200 });
   } catch (e) {
     throw new Error((e as Error).message);
@@ -50,10 +51,17 @@ export async function POST(
     const [event] = await db
       .insert(events)
       .values({
-        clubID: clubId,
+        slug: slugify(String(body.slug || body.title)),
+        clubId,
         title: body.title,
+        summary: body.summary ?? body.description ?? "",
         description: body.description,
-        date: body.date,
+        startsAt: new Date(body.startsAt ?? body.date),
+        endsAt: body.endsAt ? new Date(body.endsAt) : null,
+        location: body.location,
+        onlineUrl: body.onlineUrl,
+        registrationUrl: body.registrationUrl,
+        registrationStatus: body.registrationStatus ?? "not_required",
       })
       .returning();
 

--- a/app/api/events/route.tsx
+++ b/app/api/events/route.tsx
@@ -2,11 +2,12 @@ import { requireAdmin } from "@/lib/requireAdmin";
 
 import { db } from "@/app/db";
 import { events } from "@/app/db/schema";
+import { slugify } from "@/lib/slugify";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET() {
   try {
-    const allEvents = await db.select().from(events).orderBy(events.date);
+    const allEvents = await db.select().from(events).orderBy(events.startsAt);
     if (allEvents.length === 0) {
       return NextResponse.json(
         { message: "Sorry!! No events found" },
@@ -33,10 +34,17 @@ export async function POST(request: NextRequest) {
     const [newEvent] = await db
       .insert(events)
       .values({
-        clubID: body.clubID,
+        slug: slugify(String(body.slug || body.title)),
+        clubId: body.clubId ?? body.clubID ?? null,
         title: body.title,
+        summary: body.summary ?? body.description ?? "",
         description: body.description,
-        date: body.date,
+        startsAt: new Date(body.startsAt ?? body.date),
+        endsAt: body.endsAt ? new Date(body.endsAt) : null,
+        location: body.location,
+        onlineUrl: body.onlineUrl,
+        registrationUrl: body.registrationUrl,
+        registrationStatus: body.registrationStatus ?? "not_required",
       })
       .returning();
     return NextResponse.json(newEvent, { status: 201 });

--- a/app/api/testimonials/route.tsx
+++ b/app/api/testimonials/route.tsx
@@ -1,12 +1,12 @@
 import { requireAdmin } from "@/lib/requireAdmin";
 
 import { db } from "@/app/db";
-import { testimonies } from "@/app/db/schema";
+import { testimonials } from "@/app/db/schema";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(){
     try {
-        const allTestimonies = await db.select().from(testimonies).orderBy(testimonies.postedOn);
+        const allTestimonies = await db.select().from(testimonials).orderBy(testimonials.postedOn);
 
         if(allTestimonies.length === 0){
             return NextResponse.json({message: "Sorry!! No testimonies found"}, {status: 404})
@@ -26,9 +26,9 @@ export async function POST(request: NextRequest){
 
     try {
         const [newTestimony] = await db
-            .insert(testimonies)
+            .insert(testimonials)
             .values({
-                userId: body.userId,
+                memberId: body.memberId ?? body.userId,
                 testimony: body.testimony,
             })
             .returning();

--- a/app/api/users/clubUsers/[id]/route.tsx
+++ b/app/api/users/clubUsers/[id]/route.tsx
@@ -1,5 +1,6 @@
 import { db } from "@/app/db";
-import { userClub, users } from "@/app/db/schema";
+import { memberClub, members } from "@/app/db/schema";
+import { requireAdmin } from "@/lib/requireAdmin";
 import { eq } from "drizzle-orm";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -7,6 +8,9 @@ export async function GET(
   request: NextRequest,
   { params }: { params: Promise<{ id: string }> }
 ) {
+  const denied = await requireAdmin();
+  if (denied) return denied;
+
   try {
     const { id } = await params;
 
@@ -18,21 +22,24 @@ export async function GET(
 
     const clubusers = await db
       .select({
-        userId: users.id,
-        firstName: users.firstName,
-        lastName: users.lastName,
-        email: users.email,
+        userId: members.id,
+        firstName: members.firstName,
+        lastName: members.lastName,
+        email: members.email,
       })
-      .from(userClub)
-      .innerJoin(users, eq(userClub.userID, users.id))
-      .where(eq(userClub.clubID, clubId));
+      .from(memberClub)
+      .innerJoin(members, eq(memberClub.memberId, members.id))
+      .where(eq(memberClub.clubId, clubId));
 
     if (clubusers.length === 0) {
       return NextResponse.json([], { status: 200 });
     }
 
     return NextResponse.json(clubusers, { status: 200 });
-  } catch (error) {
-    throw new Error((error as Error).message);
+  } catch {
+    return NextResponse.json(
+      { error: "Unable to load club members" },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/users/route.tsx
+++ b/app/api/users/route.tsx
@@ -1,6 +1,6 @@
 import { requireAdmin } from "@/lib/requireAdmin";
 import { db } from "@/app/db";
-import { users } from "@/app/db/schema";
+import { members } from "@/app/db/schema";
 import { NextResponse } from "next/server";
 
 export async function GET() {
@@ -9,15 +9,15 @@ export async function GET() {
   try {
     const allUsers = await db
       .select({
-        id: users.id,
-        firstName: users.firstName,
-        lastName: users.lastName,
-        email: users.email,
-        role: users.role,
-        registeredAt: users.registeredAt,
+        id: members.id,
+        firstName: members.firstName,
+        lastName: members.lastName,
+        email: members.email,
+        status: members.status,
+        registeredAt: members.registeredAt,
       })
-      .from(users)
-      .orderBy(users.registeredAt);
+      .from(members)
+      .orderBy(members.registeredAt);
 
     if (allUsers.length === 0) {
       return NextResponse.json({ message: "No users found" }, { status: 404 });

--- a/app/api/visionMission/[id]/route.tsx
+++ b/app/api/visionMission/[id]/route.tsx
@@ -1,7 +1,7 @@
 import { requireAdmin } from "@/lib/requireAdmin";
 
 import { db } from "@/app/db";
-import { clubs, visionMission } from "@/app/db/schema";
+import { clubs } from "@/app/db/schema";
 import { eq } from "drizzle-orm";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -19,17 +19,16 @@ export async function PATCH(
       return NextResponse.json({ error: "Invalid club ID" }, { status: 400 });
     }
     const body = await request.json();
-    const [visionMissionId] = await db
-      .select({ visionMissionID: clubs.visionMissionID })
-      .from(clubs)
-      .where(eq(clubs.id, clubId));
-    if (!visionMissionId) {
-      return NextResponse.json({ error: "Club not found" }, { status: 404 });
-    }
+    const changes = {
+      vision: body.vision,
+      mission: body.mission,
+      description: body.description,
+      updatedAt: new Date(),
+    };
     const updatedvisionMission = await db
-      .update(visionMission)
-      .set(body)
-      .where(eq(visionMission.id, visionMissionId.visionMissionID))
+      .update(clubs)
+      .set(Object.fromEntries(Object.entries(changes).filter(([, value]) => value !== undefined)))
+      .where(eq(clubs.id, clubId))
       .returning();
     if (updatedvisionMission.length === 0) {
       return NextResponse.json(
@@ -52,17 +51,23 @@ export async function GET(
 ) {
   try {
     const { id } = await params;
-    const visionMissionID = parseInt(id);
-    if (isNaN(visionMissionID)) {
+    const clubId = parseInt(id);
+    if (isNaN(clubId)) {
       return NextResponse.json(
         { error: "Invalid Vision Mission Id" },
         { status: 400 }
       );
     }
     const result = await db
-      .select()
-      .from(visionMission)
-      .where(eq(visionMission.id, visionMissionID));
+      .select({
+        id: clubs.id,
+        name: clubs.title,
+        vision: clubs.vision,
+        mission: clubs.mission,
+        description: clubs.description,
+      })
+      .from(clubs)
+      .where(eq(clubs.id, clubId));
 
     if (result.length === 0) {
       return NextResponse.json({ Message: "Sorry!! No Data Found" }, { status: 404 });

--- a/app/api/visionMission/route.tsx
+++ b/app/api/visionMission/route.tsx
@@ -1,12 +1,18 @@
 import { requireAdmin } from "@/lib/requireAdmin";
 
 import { db } from "@/app/db";
-import { visionMission} from "@/app/db/schema";
-import { NextRequest, NextResponse } from "next/server";
+import { clubs } from "@/app/db/schema";
+import { NextResponse } from "next/server";
 
 export async function GET(){
     try {
-        const visionsMissions = await db.select().from(visionMission);
+        const visionsMissions = await db.select({
+          id: clubs.id,
+          name: clubs.title,
+          vision: clubs.vision,
+          mission: clubs.mission,
+          description: clubs.description,
+        }).from(clubs);
         if(visionsMissions.length === 0){
             return NextResponse.json({message: "Sorry!! No visionMission found"}, {status: 404});
         }else{
@@ -17,23 +23,12 @@ export async function GET(){
     }
 }
 
-export async function POST(request: NextRequest){
+export async function POST(){
   const denied = await requireAdmin();
   if (denied) return denied;
 
-    const body = await request.json()
-
-    try {
-        const [newVisionMission] = await db
-            .insert(visionMission)
-            .values({
-                vision: body.vision,
-                mission: body.mission,
-                description: body.description,
-            })
-            .returning();
-        return NextResponse.json(newVisionMission, {status: 201});
-    }catch(e){
-        return NextResponse.json({message: (e as Error).message}, {status: 400})
-    }
+    return NextResponse.json(
+      { message: "Vision and mission are now edited on a club" },
+      { status: 410 }
+    );
 }

--- a/app/components/CustomForm.tsx
+++ b/app/components/CustomForm.tsx
@@ -1,149 +1,66 @@
 "use client";
+
+import { useActionState } from "react";
+import {
+  initialMembershipActionState,
+  submitMembershipApplication,
+} from "@/app/(pages)/Membership/actions";
+
 export default function CustomForm() {
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-
-    const form = event.target as HTMLFormElement;
-    const firstName = (form.elements.namedItem("firstName") as HTMLInputElement).value.trim();
-    const lastName = (form.elements.namedItem("lastName") as HTMLInputElement).value.trim();
-    const options = Array.from((form.elements.namedItem("options") as HTMLSelectElement).selectedOptions).map(
-      (option) => (option as HTMLOptionElement).value
-    );
-    const file = (form.elements.namedItem("file") as HTMLInputElement).files![0];
-    const password = (form.elements.namedItem("password") as HTMLInputElement).value;
-    const confirmPassword = (form.elements.namedItem("confirmPassword") as HTMLInputElement).value;
-
-    const errors = [];
-
-    // Validation
-    if (!firstName) errors.push("First Name is required.");
-    if (!lastName) errors.push("Last Name is required.");
-    if (options.length === 0) errors.push("Select at least one option.");
-    if (!file) {
-      errors.push("File is required.");
-    } else if (!["image/jpeg", "image/jpg"].includes(file.type)) {
-      errors.push("Only jpg/jpeg files are allowed.");
-    }
-    if (password.length < 6)
-      errors.push("Password must be at least 6 characters long.");
-    if (password !== confirmPassword) errors.push("Passwords must match.");
-
-    if (errors.length > 0) {
-      alert(errors.join("\n"));
-      return;
-    }
-
-    // Submit data
-    console.log({
-      firstName,
-      lastName,
-      options,
-      fileName: file.name,
-      password,
-    });
-    alert("Form submitted successfully!");
-  };
+  const [state, formAction, pending] = useActionState(
+    submitMembershipApplication,
+    initialMembershipActionState
+  );
 
   return (
     <>
-    <div className="flex flex-col pb-4">
-
-      <span className="text-4xl font-bold">Sign Up</span>
-      <span className="pt-3 opacity-70">Join UISS and enroll in your desired program to kickstart your journey today!</span>
-    </div>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        {/* First Name */}
-        <div className="flex flex-col gap-y-1">
-          <label htmlFor="firstName" className="font-bold">
-            First Name
+      <div className="flex flex-col pb-4">
+        <span className="text-4xl font-bold">Join UISS</span>
+        <span className="pt-3 opacity-70">
+          Applications are open year-round and reviewed weekly.
+        </span>
+      </div>
+      <form action={formAction} className="space-y-4">
+        <div className="grid gap-4 sm:grid-cols-2">
+          <label className="flex flex-col gap-y-1 font-bold">
+            First name
+            <input required maxLength={100} name="firstName" autoComplete="given-name" className="rounded-md border border-black/20 px-3 py-2 font-normal focus:outline-none" />
           </label>
-          <input
-            type="text"
-            id="firstName"
-            name="firstName"
-            className="border-[1px] border-black/20 rounded-md py-1 px-3 focus:outline-none"
-          />
+          <label className="flex flex-col gap-y-1 font-bold">
+            Last name
+            <input required maxLength={100} name="lastName" autoComplete="family-name" className="rounded-md border border-black/20 px-3 py-2 font-normal focus:outline-none" />
+          </label>
         </div>
 
-        {/* Last Name */}
-        <div className="flex flex-col gap-y-1">
-          <label htmlFor="lastName" className="font-bold">
-            Last Name
-          </label>
-          <input
-            type="text"
-            id="lastName"
-            name="lastName"
-            className="border-[1px] border-black/20 rounded-md py-1 px-3 focus:outline-none"
-          />
-        </div>
+        <label className="flex flex-col gap-y-1 font-bold">
+          University email
+          <input required type="email" maxLength={254} name="email" autoComplete="email" className="rounded-md border border-black/20 px-3 py-2 font-normal focus:outline-none" />
+        </label>
 
-        {/* Options (Multi-Select) */}
-        <div className="flex flex-col gap-y-1">
-          <label htmlFor="options" className="font-bold">
-            Select Options
-          </label>
-          <select
-            id="options"
-            name="options"
-            className="border-[1px] border-black/20 rounded-md py-1 px-3 focus:outline-none"
-          >
-            <option value="option1">Option 1</option>
-            <option value="option2">Option 2</option>
-            <option value="option3">Option 3</option>
-            <option value="option4">Option 4</option>
-            <option value="option5">Option 5</option>
-            <option value="option6">Option 6</option>
-          </select>
-        </div>
+        <label className="flex flex-col gap-y-1 font-bold">
+          Club interest
+          <input required maxLength={120} name="clubInterest" placeholder="For example, cybersecurity or programming" className="rounded-md border border-black/20 px-3 py-2 font-normal focus:outline-none" />
+        </label>
 
-        {/* File Upload */}
-        <div className="flex flex-col gap-y-1">
-          <label htmlFor="file" className="font-bold">
-            Upload File (jpg, jpeg)
-          </label>
-          <input
-            type="file"
-            id="file"
-            name="file"
-            accept=".jpg,.jpeg"
-            className="input-field focus:outline-none"
-          />
-        </div>
+        <label className="flex flex-col gap-y-1 font-bold">
+          Message <span className="font-normal opacity-60">Optional</span>
+          <textarea maxLength={1000} name="message" rows={4} className="resize-none rounded-md border border-black/20 px-3 py-2 font-normal focus:outline-none" />
+        </label>
 
-        {/* Password */}
-        <div className="flex flex-col gap-y-1">
-          <label htmlFor="password" className="font-bold">
-            Password
-          </label>
-          <input
-            type="password"
-            id="password"
-            name="password"
-            className="border-[1px] border-black/20 rounded-md py-1 px-3 focus:outline-none"
-          />
-        </div>
+        <label className="hidden" aria-hidden="true">
+          Website
+          <input name="website" tabIndex={-1} autoComplete="off" />
+        </label>
 
-        {/* Confirm Password */}
-        <div className="flex flex-col gap-y-1">
-          <label htmlFor="confirmPassword" className="font-bold">
-            Confirm Password
-          </label>
-          <input
-            type="password"
-            id="confirmPassword"
-            name="confirmPassword"
-            className="border-[1px] border-black/20 rounded-md py-1 px-3 focus:outline-none"
-          />
-        </div>
+        {state.status !== "idle" && (
+          <p role="status" className={state.status === "success" ? "text-green-700" : "text-red-700"}>
+            {state.message}
+          </p>
+        )}
 
-        {/* Submit Button */}
         <div className="flex justify-end">
-          <button
-            type="submit"
-            className="btn-primary bg-ternary  text-lg font-bold py-1 px-3 rounded-md"
-          >
-            Submit
+          <button type="submit" disabled={pending} className="rounded-md bg-ternary px-4 py-2 text-lg font-bold disabled:cursor-not-allowed disabled:opacity-60">
+            {pending ? "Submitting..." : "Submit application"}
           </button>
         </div>
       </form>

--- a/app/db/schema.ts
+++ b/app/db/schema.ts
@@ -1,200 +1,285 @@
-import { relations } from "drizzle-orm";
+import { relations, sql } from "drizzle-orm";
 import {
+  bigint,
+  index,
   integer,
-  timestamp,
+  pgEnum,
+  pgSchema,
   pgTable,
-  text,
-  varchar,
   primaryKey,
+  text,
+  timestamp,
   uniqueIndex,
 } from "drizzle-orm/pg-core";
 
-// Defines the sponsors table with columns id, logo, and name
+const identity = (name: string) =>
+  bigint(name, { mode: "number" }).primaryKey().generatedAlwaysAsIdentity();
+
+export const clubStatus = pgEnum("club_status", ["active", "inactive"]);
+export const memberStatus = pgEnum("member_status", ["pending", "active", "inactive", "rejected"]);
+export const registrationStatus = pgEnum("registration_status", ["open", "closed", "full", "not_required"]);
+export const projectStatus = pgEnum("project_status", ["concept", "active", "completed"]);
+export const publicationStatus = pgEnum("publication_status", ["draft", "published"]);
+export const privateSchema = pgSchema("private");
+
+export const media = pgTable("media", {
+  id: identity("id"),
+  url: text("url").notNull(),
+  alt: text("alt").notNull(),
+  width: integer("width"),
+  height: integer("height"),
+  credit: text("credit"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+});
+
 export const sponsors = pgTable("sponsors", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  logo: text(),
-  name: varchar({ length: 255 }).notNull(),
+  id: identity("id"),
+  logo: text("logo"),
+  name: text("name").notNull(),
 });
 
-// Defines the awards_and_achievements table with columns id, title, description, and awardDate
 export const awardsAndAchievements = pgTable("awards_and_achievements", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  title: varchar({ length: 255 }).notNull(),
-  description: text(),
-  awardDate: varchar({ length: 255 }).notNull(),
+  id: identity("id"),
+  title: text("title").notNull(),
+  description: text("description"),
+  awardDate: text("award_date").notNull(),
 });
 
-// Defines the core_values table with columns id, value, and description
 export const coreValues = pgTable("core_values", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  value: varchar({ length: 255 }).notNull().unique(),
-  description: text(),
+  id: identity("id"),
+  value: text("value").notNull().unique(),
+  description: text("description"),
 });
 
-// Defines the hero_page table with columns id, section, heading, description, and backgroundImg
 export const heroPage = pgTable("hero_page", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  section: varchar({ length: 25 }).notNull().unique(),
-  heading: varchar({ length: 100 }).notNull(),
-  subheading: varchar({length: 30}).notNull(),
-  description: text().notNull(),
-  backgroundImg: varchar({ length: 255 }).notNull(),
+  id: identity("id"),
+  section: text("section").notNull().unique(),
+  heading: text("heading").notNull(),
+  subheading: text("subheading").notNull(),
+  description: text("description").notNull(),
+  backgroundImg: text("background_img").notNull(),
 });
 
-// Defines the position table with columns id and title
 export const position = pgTable("position", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  title: varchar({ length: 255 }).notNull().unique(),
+  id: identity("id"),
+  title: text("title").notNull().unique(),
 });
 
-// Defines the leaders table with columns id, firstName, lastName, positionId, year, facebook, linkedIn, instagram, and twitter
-export const leaders = pgTable("leaders", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  firstName: varchar({ length: 255 }).notNull(),
-  lastName: varchar({ length: 255 }).notNull(),
-  positionId: integer()
-    .notNull()
-    .references(() => position.id),
-  year: varchar({ length: 255 }).notNull(),
-  facebook: varchar({ length: 255 }),
-  linkedIn: varchar({ length: 255 }),
-  instagram: varchar({ length: 255 }),
-  twitter: varchar({ length: 255 }),
-  imageURL: varchar({length: 100}).default(""),
-});
-
-// Defines the users table with columns id, firstName, lastName, email, password, role, and registeredAt
-export const users = pgTable(
-  "users",
+export const leaders = pgTable(
+  "leaders",
   {
-    id: integer().primaryKey().generatedAlwaysAsIdentity(),
-    firstName: varchar({ length: 255 }).notNull(),
-    lastName: varchar({ length: 255 }).notNull(),
-    email: varchar({ length: 255 }).notNull(),
-    password: varchar({ length: 255 }).notNull(),
-    role: varchar({ length: 255 }).notNull(),
-    registeredAt: timestamp().notNull().defaultNow(),
+    id: identity("id"),
+    firstName: text("first_name").notNull(),
+    lastName: text("last_name").notNull(),
+    positionId: bigint("position_id", { mode: "number" })
+      .notNull()
+      .references(() => position.id, { onDelete: "restrict" }),
+    year: text("year").notNull(),
+    facebook: text("facebook"),
+    linkedIn: text("linkedin"),
+    instagram: text("instagram"),
+    twitter: text("twitter"),
+    imageURL: text("image_url").notNull().default(""),
   },
-  (table) => [uniqueIndex().on(table.email)]
+  (table) => [index("leaders_position_id_idx").on(table.positionId)]
 );
 
-// Defines the testimonies table with columns id, userId, testimony, and postedOn
-export const testimonies = pgTable("testimonies", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  userId: integer()
-    .notNull()
-    .references(() => users.id),
-  testimony: text(),
-  postedOn: timestamp().notNull().defaultNow(),
-});
-
-// Defines the events table with columns id, clubId, title, description, date, and addedOn
-export const events = pgTable("events", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  clubID: integer()
-    .notNull()
-    .references(() => clubs.id),
-  title: varchar({ length: 255 }).notNull(),
-  description: text(),
-  date: varchar({ length: 255 }).notNull(),
-  location: varchar({length: 255}).notNull().default(""),
-  imageURL: varchar({length: 255}).notNull().default(""),
-  addedOn: timestamp().notNull().defaultNow(),
-});
-
-// Defines the clubs table with columns id, visionMissionID, title, and description
-export const clubs = pgTable("clubs", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  visionMissionID: integer()
-    .notNull()
-    .unique()
-    .references(() => visionMission.id),
-  title: varchar({ length: 255 }).notNull(),
-  description: text(),
-  introVidId: varchar({ length: 100 }).notNull().default(""),
-});
-
-// Defines the user_club table with columns userID and clubID intersect of clubs and users table
-export const userClub = pgTable(
-  "user_club",
+export const clubs = pgTable(
+  "clubs",
   {
-    userID: integer()
-      .notNull()
-      .references(() => users.id),
-    clubID: integer()
-      .notNull()
-      .references(() => clubs.id),
+    id: identity("id"),
+    slug: text("slug").notNull(),
+    title: text("title").notNull(),
+    summary: text("summary").notNull().default(""),
+    description: text("description"),
+    vision: text("vision"),
+    mission: text("mission"),
+    disciplines: text("disciplines").array().notNull().default(sql`'{}'::text[]`),
+    skillLevels: text("skill_levels").array().notNull().default(sql`'{}'::text[]`),
+    schedule: text("schedule"),
+    location: text("location"),
+    eligibility: text("eligibility"),
+    status: clubStatus("status").notNull().default("active"),
+    introVidId: text("intro_video_id").notNull().default(""),
+    coverMediaId: bigint("cover_media_id", { mode: "number" }).references(() => media.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
   },
-  (t) => [primaryKey({ columns: [t.userID, t.clubID] })]
+  (table) => [
+    uniqueIndex("clubs_slug_uidx").on(table.slug),
+    index("clubs_cover_media_id_idx").on(table.coverMediaId),
+  ]
 );
 
-// Defines the vision_mission table with columns id, vision, mission, and description
-export const visionMission = pgTable("vision_mission", {
-  id: integer().primaryKey().generatedAlwaysAsIdentity(),
-  name: varchar({ length: 10 }).notNull().default(""),
-  vision: text(),
-  mission: text(),
-  description: text(),
+export const members = pgTable(
+  "members",
+  {
+    id: identity("id"),
+    firstName: text("first_name").notNull(),
+    lastName: text("last_name").notNull(),
+    email: text("email").notNull(),
+    clubInterest: text("club_interest").notNull(),
+    message: text("message"),
+    status: memberStatus("status").notNull().default("pending"),
+    registeredAt: timestamp("registered_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [uniqueIndex("members_email_uidx").on(table.email)]
+);
+
+export const membershipRateLimits = privateSchema.table("membership_rate_limits", {
+  keyHash: text("key_hash").primaryKey(),
+  windowStartedAt: timestamp("window_started_at", { withTimezone: true }).notNull().defaultNow(),
+  attempts: integer("attempts").notNull().default(1),
 });
 
-// Defines the relations for the users table, specifying that a user can belong to many clubs
-export const userClubRelations = relations(userClub, ({ one }) => ({
-  users: one(users, {
-    fields: [userClub.userID],
-    references: [users.id],
-  }),
-  clubs: one(clubs, {
-    fields: [userClub.clubID],
-    references: [clubs.id],
-  }),
-}));
+export const memberClub = pgTable(
+  "member_club",
+  {
+    memberId: bigint("member_id", { mode: "number" }).notNull().references(() => members.id, { onDelete: "cascade" }),
+    clubId: bigint("club_id", { mode: "number" }).notNull().references(() => clubs.id, { onDelete: "cascade" }),
+  },
+  (table) => [
+    primaryKey({ columns: [table.memberId, table.clubId] }),
+    index("member_club_club_id_idx").on(table.clubId),
+  ]
+);
 
-// Defines the relations for the position table, specifying that a position can have many leaders
-export const positionRelations = relations(position, ({ many }) => ({
-  leaders: many(leaders),
-}));
+export const testimonials = pgTable(
+  "testimonials",
+  {
+    id: identity("id"),
+    memberId: bigint("member_id", { mode: "number" }).notNull().references(() => members.id, { onDelete: "cascade" }),
+    testimony: text("testimony").notNull(),
+    postedOn: timestamp("posted_on", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [index("testimonials_member_id_idx").on(table.memberId)]
+);
 
-// Defines the relations for the leaders table, specifying that a leader has one position
+export const events = pgTable(
+  "events",
+  {
+    id: identity("id"),
+    slug: text("slug").notNull(),
+    clubId: bigint("club_id", { mode: "number" }).references(() => clubs.id, { onDelete: "set null" }),
+    title: text("title").notNull(),
+    summary: text("summary").notNull().default(""),
+    description: text("description"),
+    startsAt: timestamp("starts_at", { withTimezone: true }).notNull(),
+    endsAt: timestamp("ends_at", { withTimezone: true }),
+    location: text("location"),
+    onlineUrl: text("online_url"),
+    registrationUrl: text("registration_url"),
+    registrationStatus: registrationStatus("registration_status").notNull().default("not_required"),
+    coverMediaId: bigint("cover_media_id", { mode: "number" }).references(() => media.id, { onDelete: "set null" }),
+    addedOn: timestamp("added_on", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("events_slug_uidx").on(table.slug),
+    index("events_club_id_idx").on(table.clubId),
+    index("events_cover_media_id_idx").on(table.coverMediaId),
+    index("events_starts_at_idx").on(table.startsAt),
+  ]
+);
+
+export const projects = pgTable(
+  "projects",
+  {
+    id: identity("id"),
+    slug: text("slug").notNull(),
+    title: text("title").notNull(),
+    summary: text("summary").notNull(),
+    problem: text("problem").notNull(),
+    solution: text("solution").notNull(),
+    impact: text("impact").notNull(),
+    year: integer("year").notNull(),
+    status: projectStatus("status").notNull().default("concept"),
+    publicationStatus: publicationStatus("publication_status").notNull().default("draft"),
+    techStack: text("tech_stack").array().notNull().default(sql`'{}'::text[]`),
+    clubId: bigint("club_id", { mode: "number" }).references(() => clubs.id, { onDelete: "set null" }),
+    repositoryUrl: text("repository_url"),
+    demoUrl: text("demo_url"),
+    coverMediaId: bigint("cover_media_id", { mode: "number" }).references(() => media.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("projects_slug_uidx").on(table.slug),
+    index("projects_club_id_idx").on(table.clubId),
+    index("projects_cover_media_id_idx").on(table.coverMediaId),
+    index("projects_publication_status_idx").on(table.publicationStatus),
+  ]
+);
+
+export const projectMedia = pgTable(
+  "project_media",
+  {
+    projectId: bigint("project_id", { mode: "number" }).notNull().references(() => projects.id, { onDelete: "cascade" }),
+    mediaId: bigint("media_id", { mode: "number" }).notNull().references(() => media.id, { onDelete: "cascade" }),
+    sortOrder: integer("sort_order").notNull().default(0),
+  },
+  (table) => [
+    primaryKey({ columns: [table.projectId, table.mediaId] }),
+    index("project_media_media_id_idx").on(table.mediaId),
+  ]
+);
+
+export const news = pgTable(
+  "news",
+  {
+    id: identity("id"),
+    slug: text("slug").notNull(),
+    title: text("title").notNull(),
+    summary: text("summary").notNull(),
+    body: text("body").notNull(),
+    publishedAt: timestamp("published_at", { withTimezone: true }),
+    status: publicationStatus("status").notNull().default("draft"),
+    coverMediaId: bigint("cover_media_id", { mode: "number" }).references(() => media.id, { onDelete: "set null" }),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp("updated_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    uniqueIndex("news_slug_uidx").on(table.slug),
+    index("news_cover_media_id_idx").on(table.coverMediaId),
+    index("news_status_published_at_idx").on(table.status, table.publishedAt),
+  ]
+);
+
+export const positionRelations = relations(position, ({ many }) => ({ leaders: many(leaders) }));
 export const leadersRelations = relations(leaders, ({ one }) => ({
-  position: one(position, {
-    fields: [leaders.positionId],
-    references: [position.id],
-  }),
+  position: one(position, { fields: [leaders.positionId], references: [position.id] }),
 }));
-
-// Defines the relations for the users table, specifying that a user can have many testimonies and clubs
-export const userRelations = relations(users, ({ many }) => ({
-  testimonies: many(testimonies),
-  userClub: many(userClub),
-}));
-
-// Defines the relations for the testimonies table, specifying that a testimony belongs to one user
-export const testimoniesRelations = relations(testimonies, ({ one }) => ({
-  user: one(users, {
-    fields: [testimonies.userId],
-    references: [users.id],
-  }),
-}));
-
-// Defines the relations for the clubs table, specifying that a club has one vision and mission
 export const clubsRelations = relations(clubs, ({ one, many }) => ({
-  visionMission: one(visionMission, {
-    fields: [clubs.visionMissionID],
-    references: [visionMission.id],
-  }),
-  userClub: many(userClub),
+  coverMedia: one(media, { fields: [clubs.coverMediaId], references: [media.id] }),
+  memberClubs: many(memberClub),
   events: many(events),
+  projects: many(projects),
 }));
-
-// Defines the relations for the events table, specifying that an event belongs to one club
+export const membersRelations = relations(members, ({ many }) => ({
+  memberClubs: many(memberClub),
+  testimonials: many(testimonials),
+}));
+export const memberClubRelations = relations(memberClub, ({ one }) => ({
+  member: one(members, { fields: [memberClub.memberId], references: [members.id] }),
+  club: one(clubs, { fields: [memberClub.clubId], references: [clubs.id] }),
+}));
+export const testimonialsRelations = relations(testimonials, ({ one }) => ({
+  member: one(members, { fields: [testimonials.memberId], references: [members.id] }),
+}));
 export const eventsRelations = relations(events, ({ one }) => ({
-  clubs: one(clubs, {
-    fields: [events.clubID],
-    references: [clubs.id],
-  }),
+  club: one(clubs, { fields: [events.clubId], references: [clubs.id] }),
+  coverMedia: one(media, { fields: [events.coverMediaId], references: [media.id] }),
 }));
-
-// Defines the relations for the vision_mission table, specifying that a vision and mission can belong to one club
-export const visionMissionRelations = relations(visionMission, ({ one }) => ({
-  clubs: one(clubs),
+export const projectsRelations = relations(projects, ({ one, many }) => ({
+  club: one(clubs, { fields: [projects.clubId], references: [clubs.id] }),
+  coverMedia: one(media, { fields: [projects.coverMediaId], references: [media.id] }),
+  gallery: many(projectMedia),
+}));
+export const projectMediaRelations = relations(projectMedia, ({ one }) => ({
+  project: one(projects, { fields: [projectMedia.projectId], references: [projects.id] }),
+  media: one(media, { fields: [projectMedia.mediaId], references: [media.id] }),
+}));
+export const newsRelations = relations(news, ({ one }) => ({
+  coverMedia: one(media, { fields: [news.coverMediaId], references: [media.id] }),
 }));

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,5 +1,8 @@
-import 'dotenv/config';
+import { config } from "dotenv";
 import { defineConfig } from 'drizzle-kit';
+
+config({ path: ".env.local" });
+config();
 
 export default defineConfig({
   out: './drizzle',
@@ -8,4 +11,5 @@ export default defineConfig({
   dbCredentials: {
     url: process.env.DATABASE_URL!,
   },
+  casing: "snake_case",
 });

--- a/drizzle/0000_uiss_clean_baseline.sql
+++ b/drizzle/0000_uiss_clean_baseline.sql
@@ -1,0 +1,260 @@
+CREATE TYPE "public"."club_status" AS ENUM('active', 'inactive');--> statement-breakpoint
+CREATE TYPE "public"."member_status" AS ENUM('pending', 'active', 'inactive', 'rejected');--> statement-breakpoint
+CREATE TYPE "public"."project_status" AS ENUM('concept', 'active', 'completed');--> statement-breakpoint
+CREATE TYPE "public"."publication_status" AS ENUM('draft', 'published');--> statement-breakpoint
+CREATE TYPE "public"."registration_status" AS ENUM('open', 'closed', 'full', 'not_required');--> statement-breakpoint
+CREATE TABLE "awards_and_achievements" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "awards_and_achievements_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"title" text NOT NULL,
+	"description" text,
+	"award_date" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "clubs" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "clubs_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"slug" text NOT NULL,
+	"title" text NOT NULL,
+	"summary" text DEFAULT '' NOT NULL,
+	"description" text,
+	"vision" text,
+	"mission" text,
+	"disciplines" text[] DEFAULT '{}'::text[] NOT NULL,
+	"skill_levels" text[] DEFAULT '{}'::text[] NOT NULL,
+	"schedule" text,
+	"location" text,
+	"eligibility" text,
+	"status" "club_status" DEFAULT 'active' NOT NULL,
+	"intro_video_id" text DEFAULT '' NOT NULL,
+	"cover_media_id" bigint,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "core_values" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "core_values_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"value" text NOT NULL,
+	"description" text,
+	CONSTRAINT "core_values_value_unique" UNIQUE("value")
+);
+--> statement-breakpoint
+CREATE TABLE "events" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "events_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"slug" text NOT NULL,
+	"club_id" bigint,
+	"title" text NOT NULL,
+	"summary" text DEFAULT '' NOT NULL,
+	"description" text,
+	"starts_at" timestamp with time zone NOT NULL,
+	"ends_at" timestamp with time zone,
+	"location" text,
+	"online_url" text,
+	"registration_url" text,
+	"registration_status" "registration_status" DEFAULT 'not_required' NOT NULL,
+	"cover_media_id" bigint,
+	"added_on" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "hero_page" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "hero_page_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"section" text NOT NULL,
+	"heading" text NOT NULL,
+	"subheading" text NOT NULL,
+	"description" text NOT NULL,
+	"background_img" text NOT NULL,
+	CONSTRAINT "hero_page_section_unique" UNIQUE("section")
+);
+--> statement-breakpoint
+CREATE TABLE "leaders" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "leaders_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"position_id" bigint NOT NULL,
+	"year" text NOT NULL,
+	"facebook" text,
+	"linkedin" text,
+	"instagram" text,
+	"twitter" text,
+	"image_url" text DEFAULT '' NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "media" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "media_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"url" text NOT NULL,
+	"alt" text NOT NULL,
+	"width" integer,
+	"height" integer,
+	"credit" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "member_club" (
+	"member_id" bigint NOT NULL,
+	"club_id" bigint NOT NULL,
+	CONSTRAINT "member_club_member_id_club_id_pk" PRIMARY KEY("member_id","club_id")
+);
+--> statement-breakpoint
+CREATE TABLE "members" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "members_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"first_name" text NOT NULL,
+	"last_name" text NOT NULL,
+	"email" text NOT NULL,
+	"message" text,
+	"status" "member_status" DEFAULT 'pending' NOT NULL,
+	"registered_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "news" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "news_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"slug" text NOT NULL,
+	"title" text NOT NULL,
+	"summary" text NOT NULL,
+	"body" text NOT NULL,
+	"published_at" timestamp with time zone,
+	"status" "publication_status" DEFAULT 'draft' NOT NULL,
+	"cover_media_id" bigint,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "position" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "position_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"title" text NOT NULL,
+	CONSTRAINT "position_title_unique" UNIQUE("title")
+);
+--> statement-breakpoint
+CREATE TABLE "project_media" (
+	"project_id" bigint NOT NULL,
+	"media_id" bigint NOT NULL,
+	"sort_order" integer DEFAULT 0 NOT NULL,
+	CONSTRAINT "project_media_project_id_media_id_pk" PRIMARY KEY("project_id","media_id")
+);
+--> statement-breakpoint
+CREATE TABLE "projects" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "projects_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"slug" text NOT NULL,
+	"title" text NOT NULL,
+	"summary" text NOT NULL,
+	"problem" text NOT NULL,
+	"solution" text NOT NULL,
+	"impact" text NOT NULL,
+	"year" integer NOT NULL,
+	"status" "project_status" DEFAULT 'concept' NOT NULL,
+	"publication_status" "publication_status" DEFAULT 'draft' NOT NULL,
+	"tech_stack" text[] DEFAULT '{}'::text[] NOT NULL,
+	"club_id" bigint,
+	"repository_url" text,
+	"demo_url" text,
+	"cover_media_id" bigint,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "sponsors" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "sponsors_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"logo" text,
+	"name" text NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "testimonials" (
+	"id" bigint PRIMARY KEY GENERATED ALWAYS AS IDENTITY (sequence name "testimonials_id_seq" INCREMENT BY 1 MINVALUE 1 MAXVALUE 9223372036854775807 START WITH 1 CACHE 1),
+	"member_id" bigint NOT NULL,
+	"testimony" text NOT NULL,
+	"posted_on" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "clubs" ADD CONSTRAINT "clubs_cover_media_id_media_id_fk" FOREIGN KEY ("cover_media_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_club_id_clubs_id_fk" FOREIGN KEY ("club_id") REFERENCES "public"."clubs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_cover_media_id_media_id_fk" FOREIGN KEY ("cover_media_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "leaders" ADD CONSTRAINT "leaders_position_id_position_id_fk" FOREIGN KEY ("position_id") REFERENCES "public"."position"("id") ON DELETE restrict ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "member_club" ADD CONSTRAINT "member_club_member_id_members_id_fk" FOREIGN KEY ("member_id") REFERENCES "public"."members"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "member_club" ADD CONSTRAINT "member_club_club_id_clubs_id_fk" FOREIGN KEY ("club_id") REFERENCES "public"."clubs"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "news" ADD CONSTRAINT "news_cover_media_id_media_id_fk" FOREIGN KEY ("cover_media_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_media" ADD CONSTRAINT "project_media_project_id_projects_id_fk" FOREIGN KEY ("project_id") REFERENCES "public"."projects"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "project_media" ADD CONSTRAINT "project_media_media_id_media_id_fk" FOREIGN KEY ("media_id") REFERENCES "public"."media"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_club_id_clubs_id_fk" FOREIGN KEY ("club_id") REFERENCES "public"."clubs"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_cover_media_id_media_id_fk" FOREIGN KEY ("cover_media_id") REFERENCES "public"."media"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "testimonials" ADD CONSTRAINT "testimonials_member_id_members_id_fk" FOREIGN KEY ("member_id") REFERENCES "public"."members"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "clubs_slug_uidx" ON "clubs" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "clubs_cover_media_id_idx" ON "clubs" USING btree ("cover_media_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "events_slug_uidx" ON "events" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "events_club_id_idx" ON "events" USING btree ("club_id");--> statement-breakpoint
+CREATE INDEX "events_cover_media_id_idx" ON "events" USING btree ("cover_media_id");--> statement-breakpoint
+CREATE INDEX "events_starts_at_idx" ON "events" USING btree ("starts_at");--> statement-breakpoint
+CREATE INDEX "leaders_position_id_idx" ON "leaders" USING btree ("position_id");--> statement-breakpoint
+CREATE INDEX "member_club_club_id_idx" ON "member_club" USING btree ("club_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "members_email_uidx" ON "members" USING btree ("email");--> statement-breakpoint
+CREATE UNIQUE INDEX "news_slug_uidx" ON "news" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "news_cover_media_id_idx" ON "news" USING btree ("cover_media_id");--> statement-breakpoint
+CREATE INDEX "news_status_published_at_idx" ON "news" USING btree ("status","published_at");--> statement-breakpoint
+CREATE INDEX "project_media_media_id_idx" ON "project_media" USING btree ("media_id");--> statement-breakpoint
+CREATE UNIQUE INDEX "projects_slug_uidx" ON "projects" USING btree ("slug");--> statement-breakpoint
+CREATE INDEX "projects_club_id_idx" ON "projects" USING btree ("club_id");--> statement-breakpoint
+CREATE INDEX "projects_cover_media_id_idx" ON "projects" USING btree ("cover_media_id");--> statement-breakpoint
+CREATE INDEX "projects_publication_status_idx" ON "projects" USING btree ("publication_status");--> statement-breakpoint
+CREATE INDEX "testimonials_member_id_idx" ON "testimonials" USING btree ("member_id");--> statement-breakpoint
+
+ALTER TABLE "media" ADD CONSTRAINT "media_alt_nonempty" CHECK (length(btrim("alt")) > 0);--> statement-breakpoint
+ALTER TABLE "events" ADD CONSTRAINT "events_end_after_start" CHECK ("ends_at" IS NULL OR "ends_at" >= "starts_at");--> statement-breakpoint
+ALTER TABLE "projects" ADD CONSTRAINT "projects_year_reasonable" CHECK ("year" BETWEEN 2000 AND 2100);--> statement-breakpoint
+
+ALTER TABLE "awards_and_achievements" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "clubs" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "core_values" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "events" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "hero_page" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "leaders" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "media" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "member_club" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "members" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "news" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "position" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "project_media" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "projects" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "sponsors" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+ALTER TABLE "testimonials" ENABLE ROW LEVEL SECURITY;--> statement-breakpoint
+
+CREATE POLICY "public_read_awards" ON "awards_and_achievements" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+CREATE POLICY "public_read_active_clubs" ON "clubs" FOR SELECT TO anon, authenticated USING ("status" = 'active');--> statement-breakpoint
+CREATE POLICY "public_read_core_values" ON "core_values" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+CREATE POLICY "public_read_events" ON "events" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+CREATE POLICY "public_read_hero_page" ON "hero_page" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+CREATE POLICY "public_read_leaders" ON "leaders" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+CREATE POLICY "public_read_media" ON "media" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+CREATE POLICY "public_read_published_news" ON "news" FOR SELECT TO anon, authenticated USING ("status" = 'published');--> statement-breakpoint
+CREATE POLICY "public_read_positions" ON "position" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+CREATE POLICY "public_read_published_project_media" ON "project_media" FOR SELECT TO anon, authenticated USING (
+  EXISTS (
+    SELECT 1 FROM "projects"
+    WHERE "projects"."id" = "project_media"."project_id"
+      AND "projects"."publication_status" = 'published'
+  )
+);--> statement-breakpoint
+CREATE POLICY "public_read_published_projects" ON "projects" FOR SELECT TO anon, authenticated USING ("publication_status" = 'published');--> statement-breakpoint
+CREATE POLICY "public_read_sponsors" ON "sponsors" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+CREATE POLICY "public_read_testimonials" ON "testimonials" FOR SELECT TO anon, authenticated USING (true);--> statement-breakpoint
+
+CREATE POLICY "admin_all_awards" ON "awards_and_achievements" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_clubs" ON "clubs" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_core_values" ON "core_values" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_events" ON "events" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_hero_page" ON "hero_page" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_leaders" ON "leaders" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_media" ON "media" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_member_club" ON "member_club" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_members" ON "members" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_news" ON "news" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_positions" ON "position" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_project_media" ON "project_media" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_projects" ON "projects" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_sponsors" ON "sponsors" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+CREATE POLICY "admin_all_testimonials" ON "testimonials" FOR ALL TO authenticated USING ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin') WITH CHECK ((SELECT auth.jwt() -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated;--> statement-breakpoint
+GRANT SELECT ON "awards_and_achievements", "clubs", "core_values", "events", "hero_page", "leaders", "media", "news", "position", "project_media", "projects", "sponsors", "testimonials" TO anon, authenticated;--> statement-breakpoint
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;--> statement-breakpoint
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
+
+-- The application's DATABASE_URL connects as the table owner and therefore bypasses RLS.
+-- Every server-side mutation must continue to call requireAdmin(); RLS protects Data API access as a second layer.

--- a/drizzle/0001_rls_policy_cleanup.sql
+++ b/drizzle/0001_rls_policy_cleanup.sql
@@ -1,0 +1,59 @@
+ALTER POLICY "public_read_awards" ON "awards_and_achievements" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_active_clubs" ON "clubs" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_core_values" ON "core_values" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_events" ON "events" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_hero_page" ON "hero_page" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_leaders" ON "leaders" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_media" ON "media" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_published_news" ON "news" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_positions" ON "position" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_published_project_media" ON "project_media" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_published_projects" ON "projects" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_sponsors" ON "sponsors" TO anon;--> statement-breakpoint
+ALTER POLICY "public_read_testimonials" ON "testimonials" TO anon;--> statement-breakpoint
+
+ALTER POLICY "admin_all_awards" ON "awards_and_achievements"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_clubs" ON "clubs"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_core_values" ON "core_values"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_events" ON "events"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_hero_page" ON "hero_page"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_leaders" ON "leaders"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_media" ON "media"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_member_club" ON "member_club"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_members" ON "members"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_news" ON "news"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_positions" ON "position"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_project_media" ON "project_media"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_projects" ON "projects"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_sponsors" ON "sponsors"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');--> statement-breakpoint
+ALTER POLICY "admin_all_testimonials" ON "testimonials"
+  USING (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin')
+  WITH CHECK (((SELECT auth.jwt()) -> 'app_metadata' ->> 'role') = 'admin');

--- a/drizzle/0002_membership_intake_support.sql
+++ b/drizzle/0002_membership_intake_support.sql
@@ -1,0 +1,9 @@
+CREATE SCHEMA "private";
+--> statement-breakpoint
+CREATE TABLE "private"."membership_rate_limits" (
+	"key_hash" text PRIMARY KEY NOT NULL,
+	"window_started_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"attempts" integer DEFAULT 1 NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "members" ADD COLUMN "club_interest" text NOT NULL;

--- a/drizzle/meta/0000_snapshot.json
+++ b/drizzle/meta/0000_snapshot.json
@@ -1,0 +1,1590 @@
+{
+  "id": "7fa61de3-8d70-4446-b7de-a740d28cac05",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.awards_and_achievements": {
+      "name": "awards_and_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "awards_and_achievements_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_date": {
+          "name": "award_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clubs": {
+      "name": "clubs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "clubs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vision": {
+          "name": "vision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mission": {
+          "name": "mission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disciplines": {
+          "name": "disciplines",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "skill_levels": {
+          "name": "skill_levels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "club_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "intro_video_id": {
+          "name": "intro_video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clubs_slug_uidx": {
+          "name": "clubs_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clubs_cover_media_id_idx": {
+          "name": "clubs_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clubs_cover_media_id_media_id_fk": {
+          "name": "clubs_cover_media_id_media_id_fk",
+          "tableFrom": "clubs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_values": {
+      "name": "core_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "core_values_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_values_value_unique": {
+          "name": "core_values_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "online_url": {
+          "name": "online_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_url": {
+          "name": "registration_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_on": {
+          "name": "added_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_slug_uidx": {
+          "name": "events_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_club_id_idx": {
+          "name": "events_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_cover_media_id_idx": {
+          "name": "events_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_starts_at_idx": {
+          "name": "events_starts_at_idx",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_club_id_clubs_id_fk": {
+          "name": "events_club_id_clubs_id_fk",
+          "tableFrom": "events",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_cover_media_id_media_id_fk": {
+          "name": "events_cover_media_id_media_id_fk",
+          "tableFrom": "events",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_page": {
+      "name": "hero_page",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "hero_page_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subheading": {
+          "name": "subheading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_img": {
+          "name": "background_img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hero_page_section_unique": {
+          "name": "hero_page_section_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "section"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leaders": {
+      "name": "leaders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "leaders_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facebook": {
+          "name": "facebook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram": {
+          "name": "instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "leaders_position_id_idx": {
+          "name": "leaders_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "leaders_position_id_position_id_fk": {
+          "name": "leaders_position_id_position_id_fk",
+          "tableFrom": "leaders",
+          "tableTo": "position",
+          "columnsFrom": [
+            "position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "media_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit": {
+          "name": "credit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_club": {
+      "name": "member_club",
+      "schema": "",
+      "columns": {
+        "member_id": {
+          "name": "member_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_club_club_id_idx": {
+          "name": "member_club_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_club_member_id_members_id_fk": {
+          "name": "member_club_member_id_members_id_fk",
+          "tableFrom": "member_club",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_club_club_id_clubs_id_fk": {
+          "name": "member_club_club_id_clubs_id_fk",
+          "tableFrom": "member_club",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "member_club_member_id_club_id_pk": {
+          "name": "member_club_member_id_club_id_pk",
+          "columns": [
+            "member_id",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "members_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_email_uidx": {
+          "name": "members_email_uidx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "news_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "news_slug_uidx": {
+          "name": "news_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_cover_media_id_idx": {
+          "name": "news_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_status_published_at_idx": {
+          "name": "news_status_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "news_cover_media_id_media_id_fk": {
+          "name": "news_cover_media_id_media_id_fk",
+          "tableFrom": "news",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.position": {
+      "name": "position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "position_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "position_title_unique": {
+          "name": "position_title_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_media": {
+      "name": "project_media",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "project_media_media_id_idx": {
+          "name": "project_media_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_media_project_id_projects_id_fk": {
+          "name": "project_media_project_id_projects_id_fk",
+          "tableFrom": "project_media",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_media_media_id_media_id_fk": {
+          "name": "project_media_media_id_media_id_fk",
+          "tableFrom": "project_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_media_project_id_media_id_pk": {
+          "name": "project_media_project_id_media_id_pk",
+          "columns": [
+            "project_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "projects_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem": {
+          "name": "problem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solution": {
+          "name": "solution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'concept'"
+        },
+        "publication_status": {
+          "name": "publication_status",
+          "type": "publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "tech_stack": {
+          "name": "tech_stack",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_url": {
+          "name": "demo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_slug_uidx": {
+          "name": "projects_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_club_id_idx": {
+          "name": "projects_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_cover_media_id_idx": {
+          "name": "projects_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_publication_status_idx": {
+          "name": "projects_publication_status_idx",
+          "columns": [
+            {
+              "expression": "publication_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_club_id_clubs_id_fk": {
+          "name": "projects_club_id_clubs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_cover_media_id_media_id_fk": {
+          "name": "projects_cover_media_id_media_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sponsors": {
+      "name": "sponsors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sponsors_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testimonials": {
+      "name": "testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "testimonials_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "testimony": {
+          "name": "testimony",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posted_on": {
+          "name": "posted_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "testimonials_member_id_idx": {
+          "name": "testimonials_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "testimonials_member_id_members_id_fk": {
+          "name": "testimonials_member_id_members_id_fk",
+          "tableFrom": "testimonials",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.club_status": {
+      "name": "club_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.member_status": {
+      "name": "member_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive",
+        "rejected"
+      ]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": [
+        "concept",
+        "active",
+        "completed"
+      ]
+    },
+    "public.publication_status": {
+      "name": "publication_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed",
+        "full",
+        "not_required"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0001_snapshot.json
+++ b/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,1590 @@
+{
+  "id": "df051108-8ecd-4df2-b0be-b5509de0f817",
+  "prevId": "7fa61de3-8d70-4446-b7de-a740d28cac05",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.awards_and_achievements": {
+      "name": "awards_and_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "awards_and_achievements_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_date": {
+          "name": "award_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clubs": {
+      "name": "clubs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "clubs_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vision": {
+          "name": "vision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mission": {
+          "name": "mission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disciplines": {
+          "name": "disciplines",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "skill_levels": {
+          "name": "skill_levels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "club_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "intro_video_id": {
+          "name": "intro_video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clubs_slug_uidx": {
+          "name": "clubs_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "clubs_cover_media_id_idx": {
+          "name": "clubs_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "clubs_cover_media_id_media_id_fk": {
+          "name": "clubs_cover_media_id_media_id_fk",
+          "tableFrom": "clubs",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_values": {
+      "name": "core_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "core_values_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_values_value_unique": {
+          "name": "core_values_value_unique",
+          "columns": [
+            "value"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "events_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "online_url": {
+          "name": "online_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_url": {
+          "name": "registration_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_on": {
+          "name": "added_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_slug_uidx": {
+          "name": "events_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_club_id_idx": {
+          "name": "events_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_cover_media_id_idx": {
+          "name": "events_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "events_starts_at_idx": {
+          "name": "events_starts_at_idx",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "events_club_id_clubs_id_fk": {
+          "name": "events_club_id_clubs_id_fk",
+          "tableFrom": "events",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "tableTo": "clubs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "events_cover_media_id_media_id_fk": {
+          "name": "events_cover_media_id_media_id_fk",
+          "tableFrom": "events",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_page": {
+      "name": "hero_page",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "hero_page_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subheading": {
+          "name": "subheading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_img": {
+          "name": "background_img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hero_page_section_unique": {
+          "name": "hero_page_section_unique",
+          "columns": [
+            "section"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leaders": {
+      "name": "leaders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "leaders_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facebook": {
+          "name": "facebook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram": {
+          "name": "instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "leaders_position_id_idx": {
+          "name": "leaders_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "leaders_position_id_position_id_fk": {
+          "name": "leaders_position_id_position_id_fk",
+          "tableFrom": "leaders",
+          "columnsFrom": [
+            "position_id"
+          ],
+          "tableTo": "position",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "restrict"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "media_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit": {
+          "name": "credit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_club": {
+      "name": "member_club",
+      "schema": "",
+      "columns": {
+        "member_id": {
+          "name": "member_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_club_club_id_idx": {
+          "name": "member_club_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "member_club_member_id_members_id_fk": {
+          "name": "member_club_member_id_members_id_fk",
+          "tableFrom": "member_club",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "tableTo": "members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "member_club_club_id_clubs_id_fk": {
+          "name": "member_club_club_id_clubs_id_fk",
+          "tableFrom": "member_club",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "tableTo": "clubs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "member_club_member_id_club_id_pk": {
+          "name": "member_club_member_id_club_id_pk",
+          "columns": [
+            "member_id",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "members_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_email_uidx": {
+          "name": "members_email_uidx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "news_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "news_slug_uidx": {
+          "name": "news_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "news_cover_media_id_idx": {
+          "name": "news_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "news_status_published_at_idx": {
+          "name": "news_status_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "news_cover_media_id_media_id_fk": {
+          "name": "news_cover_media_id_media_id_fk",
+          "tableFrom": "news",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.position": {
+      "name": "position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "position_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "position_title_unique": {
+          "name": "position_title_unique",
+          "columns": [
+            "title"
+          ],
+          "nullsNotDistinct": false
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_media": {
+      "name": "project_media",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "project_media_media_id_idx": {
+          "name": "project_media_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "project_media_project_id_projects_id_fk": {
+          "name": "project_media_project_id_projects_id_fk",
+          "tableFrom": "project_media",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "tableTo": "projects",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        },
+        "project_media_media_id_media_id_fk": {
+          "name": "project_media_media_id_media_id_fk",
+          "tableFrom": "project_media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_media_project_id_media_id_pk": {
+          "name": "project_media_project_id_media_id_pk",
+          "columns": [
+            "project_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "projects_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem": {
+          "name": "problem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solution": {
+          "name": "solution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'concept'"
+        },
+        "publication_status": {
+          "name": "publication_status",
+          "type": "publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "tech_stack": {
+          "name": "tech_stack",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_url": {
+          "name": "demo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_slug_uidx": {
+          "name": "projects_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "projects_club_id_idx": {
+          "name": "projects_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "projects_cover_media_id_idx": {
+          "name": "projects_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        },
+        "projects_publication_status_idx": {
+          "name": "projects_publication_status_idx",
+          "columns": [
+            {
+              "expression": "publication_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "projects_club_id_clubs_id_fk": {
+          "name": "projects_club_id_clubs_id_fk",
+          "tableFrom": "projects",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "tableTo": "clubs",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        },
+        "projects_cover_media_id_media_id_fk": {
+          "name": "projects_cover_media_id_media_id_fk",
+          "tableFrom": "projects",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "tableTo": "media",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "set null"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sponsors": {
+      "name": "sponsors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "sponsors_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testimonials": {
+      "name": "testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "name": "testimonials_id_seq",
+            "increment": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "startWith": "1",
+            "cache": "1",
+            "cycle": false,
+            "schema": "public",
+            "type": "always"
+          }
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "testimony": {
+          "name": "testimony",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posted_on": {
+          "name": "posted_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "testimonials_member_id_idx": {
+          "name": "testimonials_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "with": {},
+          "method": "btree",
+          "concurrently": false
+        }
+      },
+      "foreignKeys": {
+        "testimonials_member_id_members_id_fk": {
+          "name": "testimonials_member_id_members_id_fk",
+          "tableFrom": "testimonials",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "tableTo": "members",
+          "columnsTo": [
+            "id"
+          ],
+          "onUpdate": "no action",
+          "onDelete": "cascade"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.club_status": {
+      "name": "club_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.member_status": {
+      "name": "member_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive",
+        "rejected"
+      ]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": [
+        "concept",
+        "active",
+        "completed"
+      ]
+    },
+    "public.publication_status": {
+      "name": "publication_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed",
+        "full",
+        "not_required"
+      ]
+    }
+  },
+  "schemas": {},
+  "views": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0002_snapshot.json
+++ b/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,1631 @@
+{
+  "id": "b561c927-4d3b-4a9a-96bb-feca8566faff",
+  "prevId": "df051108-8ecd-4df2-b0be-b5509de0f817",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.awards_and_achievements": {
+      "name": "awards_and_achievements",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "awards_and_achievements_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "award_date": {
+          "name": "award_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.clubs": {
+      "name": "clubs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "clubs_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "vision": {
+          "name": "vision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mission": {
+          "name": "mission",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disciplines": {
+          "name": "disciplines",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "skill_levels": {
+          "name": "skill_levels",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "schedule": {
+          "name": "schedule",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "eligibility": {
+          "name": "eligibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "club_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "intro_video_id": {
+          "name": "intro_video_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "clubs_slug_uidx": {
+          "name": "clubs_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "clubs_cover_media_id_idx": {
+          "name": "clubs_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "clubs_cover_media_id_media_id_fk": {
+          "name": "clubs_cover_media_id_media_id_fk",
+          "tableFrom": "clubs",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.core_values": {
+      "name": "core_values",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "core_values_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "core_values_value_unique": {
+          "name": "core_values_value_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "value"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.events": {
+      "name": "events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "events_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starts_at": {
+          "name": "starts_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ends_at": {
+          "name": "ends_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "online_url": {
+          "name": "online_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_url": {
+          "name": "registration_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "registration_status": {
+          "name": "registration_status",
+          "type": "registration_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'not_required'"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "added_on": {
+          "name": "added_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "events_slug_uidx": {
+          "name": "events_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_club_id_idx": {
+          "name": "events_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_cover_media_id_idx": {
+          "name": "events_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "events_starts_at_idx": {
+          "name": "events_starts_at_idx",
+          "columns": [
+            {
+              "expression": "starts_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "events_club_id_clubs_id_fk": {
+          "name": "events_club_id_clubs_id_fk",
+          "tableFrom": "events",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "events_cover_media_id_media_id_fk": {
+          "name": "events_cover_media_id_media_id_fk",
+          "tableFrom": "events",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hero_page": {
+      "name": "hero_page",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "hero_page_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "section": {
+          "name": "section",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "heading": {
+          "name": "heading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subheading": {
+          "name": "subheading",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "background_img": {
+          "name": "background_img",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "hero_page_section_unique": {
+          "name": "hero_page_section_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "section"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leaders": {
+      "name": "leaders",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "leaders_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_id": {
+          "name": "position_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "facebook": {
+          "name": "facebook",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "linkedin": {
+          "name": "linkedin",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram": {
+          "name": "instagram",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "twitter": {
+          "name": "twitter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        }
+      },
+      "indexes": {
+        "leaders_position_id_idx": {
+          "name": "leaders_position_id_idx",
+          "columns": [
+            {
+              "expression": "position_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "leaders_position_id_position_id_fk": {
+          "name": "leaders_position_id_position_id_fk",
+          "tableFrom": "leaders",
+          "tableTo": "position",
+          "columnsFrom": [
+            "position_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "restrict",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.media": {
+      "name": "media",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "media_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "alt": {
+          "name": "alt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "width": {
+          "name": "width",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "height": {
+          "name": "height",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "credit": {
+          "name": "credit",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.member_club": {
+      "name": "member_club",
+      "schema": "",
+      "columns": {
+        "member_id": {
+          "name": "member_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "member_club_club_id_idx": {
+          "name": "member_club_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "member_club_member_id_members_id_fk": {
+          "name": "member_club_member_id_members_id_fk",
+          "tableFrom": "member_club",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "member_club_club_id_clubs_id_fk": {
+          "name": "member_club_club_id_clubs_id_fk",
+          "tableFrom": "member_club",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "member_club_member_id_club_id_pk": {
+          "name": "member_club_member_id_club_id_pk",
+          "columns": [
+            "member_id",
+            "club_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.members": {
+      "name": "members",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "members_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "club_interest": {
+          "name": "club_interest",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "member_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "registered_at": {
+          "name": "registered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "members_email_uidx": {
+          "name": "members_email_uidx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "private.membership_rate_limits": {
+      "name": "membership_rate_limits",
+      "schema": "private",
+      "columns": {
+        "key_hash": {
+          "name": "key_hash",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "window_started_at": {
+          "name": "window_started_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.news": {
+      "name": "news",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "news_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "news_slug_uidx": {
+          "name": "news_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_cover_media_id_idx": {
+          "name": "news_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "news_status_published_at_idx": {
+          "name": "news_status_published_at_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "published_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "news_cover_media_id_media_id_fk": {
+          "name": "news_cover_media_id_media_id_fk",
+          "tableFrom": "news",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.position": {
+      "name": "position",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "position_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "position_title_unique": {
+          "name": "position_title_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.project_media": {
+      "name": "project_media",
+      "schema": "",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "media_id": {
+          "name": "media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "project_media_media_id_idx": {
+          "name": "project_media_media_id_idx",
+          "columns": [
+            {
+              "expression": "media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "project_media_project_id_projects_id_fk": {
+          "name": "project_media_project_id_projects_id_fk",
+          "tableFrom": "project_media",
+          "tableTo": "projects",
+          "columnsFrom": [
+            "project_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "project_media_media_id_media_id_fk": {
+          "name": "project_media_media_id_media_id_fk",
+          "tableFrom": "project_media",
+          "tableTo": "media",
+          "columnsFrom": [
+            "media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_media_project_id_media_id_pk": {
+          "name": "project_media_project_id_media_id_pk",
+          "columns": [
+            "project_id",
+            "media_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.projects": {
+      "name": "projects",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "projects_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "slug": {
+          "name": "slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "summary": {
+          "name": "summary",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "problem": {
+          "name": "problem",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "solution": {
+          "name": "solution",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impact": {
+          "name": "impact",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "project_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'concept'"
+        },
+        "publication_status": {
+          "name": "publication_status",
+          "type": "publication_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'draft'"
+        },
+        "tech_stack": {
+          "name": "tech_stack",
+          "type": "text[]",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{}'::text[]"
+        },
+        "club_id": {
+          "name": "club_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "demo_url": {
+          "name": "demo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_media_id": {
+          "name": "cover_media_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "projects_slug_uidx": {
+          "name": "projects_slug_uidx",
+          "columns": [
+            {
+              "expression": "slug",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_club_id_idx": {
+          "name": "projects_club_id_idx",
+          "columns": [
+            {
+              "expression": "club_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_cover_media_id_idx": {
+          "name": "projects_cover_media_id_idx",
+          "columns": [
+            {
+              "expression": "cover_media_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "projects_publication_status_idx": {
+          "name": "projects_publication_status_idx",
+          "columns": [
+            {
+              "expression": "publication_status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "projects_club_id_clubs_id_fk": {
+          "name": "projects_club_id_clubs_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "clubs",
+          "columnsFrom": [
+            "club_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        },
+        "projects_cover_media_id_media_id_fk": {
+          "name": "projects_cover_media_id_media_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "media",
+          "columnsFrom": [
+            "cover_media_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sponsors": {
+      "name": "sponsors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "sponsors_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "logo": {
+          "name": "logo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.testimonials": {
+      "name": "testimonials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "testimonials_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "member_id": {
+          "name": "member_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "testimony": {
+          "name": "testimony",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "posted_on": {
+          "name": "posted_on",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "testimonials_member_id_idx": {
+          "name": "testimonials_member_id_idx",
+          "columns": [
+            {
+              "expression": "member_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "testimonials_member_id_members_id_fk": {
+          "name": "testimonials_member_id_members_id_fk",
+          "tableFrom": "testimonials",
+          "tableTo": "members",
+          "columnsFrom": [
+            "member_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.club_status": {
+      "name": "club_status",
+      "schema": "public",
+      "values": [
+        "active",
+        "inactive"
+      ]
+    },
+    "public.member_status": {
+      "name": "member_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "active",
+        "inactive",
+        "rejected"
+      ]
+    },
+    "public.project_status": {
+      "name": "project_status",
+      "schema": "public",
+      "values": [
+        "concept",
+        "active",
+        "completed"
+      ]
+    },
+    "public.publication_status": {
+      "name": "publication_status",
+      "schema": "public",
+      "values": [
+        "draft",
+        "published"
+      ]
+    },
+    "public.registration_status": {
+      "name": "registration_status",
+      "schema": "public",
+      "values": [
+        "open",
+        "closed",
+        "full",
+        "not_required"
+      ]
+    }
+  },
+  "schemas": {
+    "private": "private"
+  },
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -1,0 +1,27 @@
+{
+  "version": "7",
+  "dialect": "postgresql",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "7",
+      "when": 1788361044902,
+      "tag": "0000_uiss_clean_baseline",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1788361276371,
+      "tag": "0001_rls_policy_cleanup",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1788361695067,
+      "tag": "0002_membership_intake_support",
+      "breakpoints": true
+    }
+  ]
+}

--- a/lib/slugify.ts
+++ b/lib/slugify.ts
@@ -1,0 +1,8 @@
+export function slugify(value: string): string {
+  return value
+    .normalize("NFKD")
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "pg": "^8.13.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "resend": "6.25.0",
         "sonner": "^2.0.1",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
@@ -2653,6 +2654,12 @@
       "integrity": "sha512-WJgX9nzTqknM393q1QJDJmoW28kUfEnybeTfVNcNAPnIx210RXm2DiXiHzfNPJNIUUb1tJnz/l4QGtJ30PgWmA==",
       "dev": true
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.15",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
@@ -4613,6 +4620,12 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.17.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
@@ -6240,6 +6253,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.4.47",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.47.tgz",
@@ -6618,6 +6637,27 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/resend": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.25.0.tgz",
+      "integrity": "sha512-iptUEycs+6Hu+W8mExK708LrDiMYOuGgnCP+wTD5L4Zrqqd2B86h1oyAmNe0khZWQw0ccI7jz8OgAaplEsyaIA==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.8",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
@@ -6919,6 +6959,16 @@
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
       }
     },
     "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "tsx scripts/migrate.ts"
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.2",
@@ -27,6 +29,7 @@
     "pg": "^8.13.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "resend": "6.25.0",
     "sonner": "^2.0.1",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,0 +1,23 @@
+import { config } from "dotenv";
+import { migrate } from "drizzle-orm/node-postgres/migrator";
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+
+config({ path: ".env.local" });
+config();
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is required");
+}
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: 1,
+  ssl: true,
+});
+
+try {
+  await migrate(drizzle(pool), { migrationsFolder: "./drizzle" });
+} finally {
+  await pool.end();
+}


### PR DESCRIPTION
## Summary

- replace the stale credential-bearing member model with the ratified credential-free Supabase schema
- add versioned Drizzle migrations, RLS policies, grants, and migration tooling
- add the validated membership Server Action, pending queue, duplicate handling, honeypot, and database-backed rate limiting
- update legacy APIs and event consumers for the new schema
- protect the remaining club-member email endpoint with the admin guard
- add Resend notification support behind complete environment configuration

UISS confirmed that the empty `UissWebsite` Supabase project is the replacement database, so the clean baseline was applied there directly. No staging project was created. The migration ledger is synchronized with the three committed migrations.

The Vercel project is linked under `geek-commits-projects/uiss-website`; production database and Resend credentials are stored there as environment variables. Sender-domain activation is intentionally deferred to #58. Membership applications continue to save to the Supabase pending queue while email is disabled.

## Verification

- `npm run lint` passes with 32 existing warnings and no errors
- `npx tsc --noEmit` passes
- `npm run build` passes
- Supabase membership insert and rate-limit transaction passes, then rolls back with no test rows left behind
- Supabase security advisor reports no findings
- performance advisor reports only expected unused-index informational notices on the empty database
- tracked-file secret scan passes

Closes #56