### PR TITLE
Build the approved UISS homepage

### DIFF
--- a/app/db/index.ts
+++ b/app/db/index.ts
@@ -5,6 +5,9 @@ import * as schema from "./schema"; // Your schema file
 
 const pool = new Pool({
   connectionString: process.env.DATABASE_URL,
+  max: 5,
+  connectionTimeoutMillis: 5_000,
+  idleTimeoutMillis: 10_000,
   // TLS verification on by default; set DATABASE_SSL_REJECT_UNAUTHORIZED=false
   // only for local development against pools with self-signed certs.
   ssl:
@@ -14,4 +17,3 @@ const pool = new Pool({
 });
 
 export const db = drizzle(pool, { schema });
-

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,15 +1,128 @@
-export const dynamic = "force-dynamic";
+import type { Metadata } from 'next'
+import { About3 } from '@/components/about3'
+import { Blog7, type Blog7Post } from '@/components/blog7'
+import { Community1 } from '@/components/community1'
+import { Cta4 } from '@/components/cta4'
+import Footer from '@/components/footer-2'
+import { HeroHeader } from '@/components/header'
+import { ClubShowcase, type ClubPreview } from '@/components/home/club-showcase'
+import { EventShowcase, type EventPreview } from '@/components/home/event-showcase'
+import { Hero12 } from '@/components/hero12'
+import { Projects5, type ProjectPreview } from '@/components/projects5'
+import { Team1, type TeamMember } from '@/components/team1'
+import { getHomepageData } from '@/lib/homepage-data'
 
-import React from "react";
-import WebLayout from "./(pages)/layout";
-import Index from "./(pages)/Home/Index";
-
-function Home() {
-  return (
-    <WebLayout>
-      <Index/>
-    </WebLayout>
-  );
+export const metadata: Metadata = {
+    title: 'UISS | Learn, build, and lead',
+    description: 'The University of Dar es Salaam ICT Students’ Society connects students through practical learning, projects, events, and technical communities.',
 }
 
-export default Home;
+export const revalidate = 3600
+
+const dateFormatter = new Intl.DateTimeFormat('en-TZ', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+    timeZone: 'Africa/Dar_es_Salaam',
+})
+
+export default async function Home() {
+    const data = await getHomepageData()
+    const hero = data.hero.data
+
+    const clubPreviews: ClubPreview[] = data.clubs.data.map((club) => ({
+        id: String(club.id),
+        title: club.title,
+        summary: club.summary,
+        disciplines: club.disciplines,
+        url: '/clubs',
+    }))
+
+    const eventPreviews: EventPreview[] = data.events.data.map((event) => ({
+        id: String(event.id),
+        title: event.title,
+        summary: event.summary,
+        date: dateFormatter.format(event.startsAt),
+        location: event.location ?? undefined,
+        registrationStatus: event.registrationStatus,
+        url: '/events',
+    }))
+
+    const projectPreviews: ProjectPreview[] = data.projects.data.map((project) => ({
+        id: String(project.id),
+        title: project.title,
+        image: project.coverMedia?.url,
+        status: project.status,
+        type: project.techStack.slice(0, 2).join(' · ') || `UISS project · ${project.year}`,
+        url: '/projects',
+    }))
+
+    const teamMembers: TeamMember[] = data.leaders.data.map((leader) => ({
+        id: String(leader.id),
+        name: `${leader.firstName} ${leader.lastName}`,
+        role: leader.position.title,
+        avatar: leader.imageURL || undefined,
+    }))
+
+    const blogPosts: Blog7Post[] = data.blog.posts.slice(0, 3).map((post) => ({
+        id: post.slug,
+        title: post.title,
+        summary: post.excerpt,
+        label: post.category?.name ?? 'UISS',
+        author: post.authors.map((author) => author.name).join(', ') || 'UISS',
+        published: dateFormatter.format(new Date(post.published_at)),
+        url: `/blog/${post.slug}`,
+        image: post.cover_image,
+    }))
+
+    const blogEmptyMessage = data.blog.unavailable
+        ? 'The UISS blog is connected, but articles could not be loaded right now. Please try again later.'
+        : data.blog.configured
+            ? 'The UISS blog is connected. The first published article will appear here automatically, with new publications checked hourly.'
+            : 'Published UISS stories will appear here after the blog connection is configured.'
+
+    return (
+        <div className="min-h-screen bg-canvas text-ink">
+            <HeroHeader />
+            <main>
+                <Hero12
+                    eyebrow={hero?.section === 'homepage' ? 'University of Dar es Salaam' : undefined}
+                    heading={hero?.heading}
+                    highlightedHeading={hero?.subheading}
+                    description={hero?.description}
+                />
+                <About3
+                    stats={[]}
+                    sections={[
+                        { title: 'Our purpose', content: 'UISS brings ICT students together around practical learning, technical collaboration, leadership, and professional growth.' },
+                        { title: 'Our community', content: 'Students can discover clubs, take part in events, share useful ideas, and turn classroom knowledge into practical work.' },
+                    ]}
+                />
+                <ClubShowcase clubs={clubPreviews} unavailable={data.clubs.unavailable} />
+                <Projects5
+                    heading="Work built by UISS students."
+                    description="Explore practical projects created by students across the UISS community."
+                    projects={projectPreviews}
+                    emptyMessage={data.projects.unavailable ? 'Project information could not be loaded right now. Please try again later.' : undefined}
+                />
+                <EventShowcase events={eventPreviews} unavailable={data.events.unavailable} />
+                <Team1
+                    heading="Meet the UISS leadership team."
+                    description="The student leaders coordinating the society, its programs, and its community."
+                    members={teamMembers}
+                    emptyMessage={data.leaders.unavailable ? 'Leadership information could not be loaded right now. Please try again later.' : undefined}
+                />
+                <Blog7
+                    headingLevel="h2"
+                    heading="Ideas and stories from our community."
+                    posts={blogPosts}
+                    emptyMessage={blogEmptyMessage}
+                    className="bg-surface"
+                />
+                <Community1 />
+                <Cta4 />
+            </main>
+            <Footer />
+        </div>
+    )
+}

--- a/components/about3.tsx
+++ b/components/about3.tsx
@@ -45,14 +45,16 @@ const About3 = ({
                     <Image src="/ctfWinner.jpg" alt="Students participating in a UISS activity" width={1200} height={900} className="aspect-[4/3] size-full rounded-lg object-cover" />
                 </div>
             </div>
-            <div className="mt-16 grid gap-5 md:grid-cols-3">
-                {stats.map((stat) => (
-                    <Card key={stat.label} variant="soft">
-                        <CardHeader><CardTitle className="text-4xl">{stat.value}</CardTitle><p className="font-bold text-ink">{stat.label}</p></CardHeader>
-                        <CardContent><p className="leading-7 text-muted">{stat.description}</p></CardContent>
-                    </Card>
-                ))}
-            </div>
+            {stats.length > 0 ? (
+                <div className="mt-16 grid gap-5 md:grid-cols-3">
+                    {stats.map((stat) => (
+                        <Card key={stat.label} variant="soft">
+                            <CardHeader><CardTitle className="text-4xl">{stat.value}</CardTitle><p className="font-bold text-ink">{stat.label}</p></CardHeader>
+                            <CardContent><p className="leading-7 text-muted">{stat.description}</p></CardContent>
+                        </Card>
+                    ))}
+                </div>
+            ) : null}
             <div className="mt-16 grid gap-10 border-t border-line pt-12 md:grid-cols-2">
                 {sections.map((section) => (
                     <div key={section.title}>

--- a/components/blog7.tsx
+++ b/components/blog7.tsx
@@ -23,6 +23,7 @@ interface Blog7Props {
     posts?: Blog7Post[]
     emptyMessage?: string
     className?: string
+    headingLevel?: 'h1' | 'h2'
 }
 
 const previewPosts: Blog7Post[] = [
@@ -38,12 +39,17 @@ const Blog7 = ({
     posts = previewPosts,
     emptyMessage = 'The Zenblog publication is connected. Your first published article will appear here automatically, with new publications checked hourly.',
     className,
-}: Blog7Props) => (
+    headingLevel = 'h1',
+}: Blog7Props) => {
+    const Heading = headingLevel
+    const EmptyHeading = headingLevel === 'h1' ? 'h2' : 'h3'
+
+    return (
     <section className={cn('py-24 sm:py-32', className)}>
         <div className="container mx-auto flex flex-col items-center gap-10 px-6">
             <div className="max-w-3xl text-center">
                 <Badge variant="secondary">{tagline}</Badge>
-                <h1 className="mt-6 text-balance text-5xl font-bold tracking-tight text-ink sm:text-6xl">{heading}</h1>
+                <Heading className="mt-6 text-balance text-5xl font-bold tracking-tight text-ink sm:text-6xl">{heading}</Heading>
                 <p className="mt-5 text-lg leading-8 text-muted">{description}</p>
             </div>
             {posts.length > 0 ? (
@@ -66,12 +72,13 @@ const Blog7 = ({
             ) : (
                 <div className="flex w-full max-w-3xl flex-col items-center rounded-lg border border-dashed border-line bg-surface p-10 text-center">
                     <Newspaper className="size-10 text-muted" aria-hidden />
-                    <h2 className="mt-5 text-2xl font-bold text-ink">Stories are being prepared.</h2>
+                    <EmptyHeading className="mt-5 text-2xl font-bold text-ink">Stories are being prepared.</EmptyHeading>
                     <p className="mt-3 max-w-xl leading-7 text-muted">{emptyMessage}</p>
                 </div>
             )}
         </div>
     </section>
-)
+    )
+}
 
 export { Blog7 }

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link'
+import { Menu } from 'lucide-react'
 import { Logo } from '@/components/logo'
 import { Button } from '@/components/ui/button'
 
@@ -24,9 +25,23 @@ export const HeroHeader = () => (
                     </li>
                 ))}
             </ul>
-            <Button asChild variant="secondary">
-                <Link href="/Membership">Join UISS</Link>
-            </Button>
+            <div className="hidden md:block">
+                <Button asChild variant="secondary">
+                    <Link href="/Membership">Join UISS</Link>
+                </Button>
+            </div>
+            <details className="group relative md:hidden">
+                <summary className="flex size-10 cursor-pointer list-none items-center justify-center rounded-lg border border-line bg-canvas text-ink [&::-webkit-details-marker]:hidden">
+                    <Menu aria-hidden />
+                    <span className="sr-only">Open navigation menu</span>
+                </summary>
+                <div className="absolute right-0 top-12 z-50 w-56 rounded-lg border border-line bg-canvas p-2 shadow-soft">
+                    {menuItems.map((item) => (
+                        <Link key={item.name} href={item.href} className="block rounded-md px-4 py-3 font-semibold text-ink hover:bg-surface">{item.name}</Link>
+                    ))}
+                    <Link href="/Membership" className="mt-2 block rounded-md bg-ink px-4 py-3 text-center font-semibold text-canvas">Join UISS</Link>
+                </div>
+            </details>
         </nav>
     </header>
 )

--- a/components/hero12.tsx
+++ b/components/hero12.tsx
@@ -7,6 +7,10 @@ import { cn } from '@/lib/utils'
 interface Hero12Props {
     className?: string
     preview?: boolean
+    eyebrow?: string
+    heading?: string
+    highlightedHeading?: string
+    description?: string
 }
 
 const destinations = [
@@ -16,7 +20,14 @@ const destinations = [
     { label: 'Blog', href: '/blog', icon: Newspaper },
 ]
 
-const Hero12 = ({ className, preview = false }: Hero12Props) => {
+const Hero12 = ({
+    className,
+    preview = false,
+    eyebrow = 'University of Dar es Salaam',
+    heading = 'Where ICT students',
+    highlightedHeading = 'learn, build, and lead.',
+    description = 'UISS connects students with practical programs, a growing technical community, and opportunities to turn ideas into useful work.',
+}: Hero12Props) => {
     const Heading = preview ? 'h2' : 'h1'
 
     return (
@@ -30,12 +41,12 @@ const Hero12 = ({ className, preview = false }: Hero12Props) => {
                     <div className="rounded-xl border border-line bg-canvas/80 p-4 shadow-soft backdrop-blur-sm">
                         <LogoIcon className="size-14" />
                     </div>
-                    <p className="mt-8 text-sm font-bold uppercase tracking-[0.18em] text-muted">University of Dar es Salaam</p>
+                    <p className="mt-8 text-sm font-bold uppercase tracking-[0.18em] text-muted">{eyebrow}</p>
                     <Heading className="mt-5 max-w-4xl text-balance text-5xl font-bold leading-[0.98] tracking-tight text-ink sm:text-6xl lg:text-7xl">
-                        Where ICT students <span className="text-brand-mark">learn, build, and lead.</span>
+                        {heading} {highlightedHeading ? <span className="text-brand-mark">{highlightedHeading}</span> : null}
                     </Heading>
                     <p className="mt-6 max-w-2xl text-pretty text-xl leading-8 text-muted">
-                        UISS connects students with practical programs, a growing technical community, and opportunities to turn ideas into useful work.
+                        {description}
                     </p>
                     <div className="mt-8 flex flex-wrap justify-center gap-3">
                         <Button asChild size="lg" variant="secondary">

--- a/components/home/club-showcase.tsx
+++ b/components/home/club-showcase.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link'
+import { ArrowRight, UsersRound } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+
+export type ClubPreview = {
+    id: string
+    title: string
+    summary: string
+    disciplines: string[]
+    url: string
+}
+
+type ClubShowcaseProps = {
+    clubs: ClubPreview[]
+    unavailable?: boolean
+}
+
+export function ClubShowcase({ clubs, unavailable = false }: ClubShowcaseProps) {
+    return (
+        <section className="bg-surface py-24 sm:py-32">
+            <div className="container mx-auto px-6">
+                <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
+                    <div className="max-w-3xl">
+                        <p className="text-sm font-bold uppercase tracking-[0.18em] text-muted">Find your community</p>
+                        <h2 className="mt-4 text-5xl font-bold tracking-tight text-ink sm:text-6xl">Explore UISS clubs.</h2>
+                        <p className="mt-5 text-lg leading-8 text-muted">Meet students who share your interests and build practical skills together.</p>
+                    </div>
+                    <Button asChild variant="outline"><Link href="/clubs">View all clubs<ArrowRight data-icon="inline-end" /></Link></Button>
+                </div>
+
+                {clubs.length > 0 ? (
+                    <div className="mt-12 grid gap-5 md:grid-cols-2 lg:grid-cols-4">
+                        {clubs.map((club) => (
+                            <Card key={club.id} className="flex min-h-72 flex-col">
+                                <CardHeader>
+                                    <div className="flex size-11 items-center justify-center rounded-lg bg-brand-mark/15 text-brand-mark"><UsersRound aria-hidden /></div>
+                                    <CardTitle className="mt-5 text-2xl"><Link href={club.url} className="hover:underline">{club.title}</Link></CardTitle>
+                                </CardHeader>
+                                <CardContent className="flex-1">
+                                    <p className="leading-7 text-muted">{club.summary || 'Club details are being prepared.'}</p>
+                                    {club.disciplines.length > 0 ? <div className="mt-5 flex flex-wrap gap-2">{club.disciplines.slice(0, 3).map((item) => <Badge key={item} variant="outline">{item}</Badge>)}</div> : null}
+                                </CardContent>
+                                <CardFooter><Link href={club.url} className="flex items-center gap-2 font-semibold text-ink hover:underline">Explore club<ArrowRight aria-hidden /></Link></CardFooter>
+                            </Card>
+                        ))}
+                    </div>
+                ) : (
+                    <div className="mt-12 rounded-lg border border-dashed border-line bg-canvas p-10 text-center">
+                        <UsersRound className="mx-auto size-10 text-muted" aria-hidden />
+                        <h3 className="mt-5 text-2xl font-bold text-ink">Club profiles are being prepared.</h3>
+                        <p className="mx-auto mt-3 max-w-xl leading-7 text-muted">{unavailable ? 'Club information could not be loaded right now. Please try again later.' : 'Approved club information will appear here as it is added by the UISS team.'}</p>
+                    </div>
+                )}
+            </div>
+        </section>
+    )
+}

--- a/components/home/event-showcase.tsx
+++ b/components/home/event-showcase.tsx
@@ -1,0 +1,65 @@
+import Link from 'next/link'
+import { ArrowRight, CalendarDays, MapPin } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+
+export type EventPreview = {
+    id: string
+    title: string
+    summary: string
+    date: string
+    location?: string
+    registrationStatus: string
+    url: string
+}
+
+type EventShowcaseProps = {
+    events: EventPreview[]
+    unavailable?: boolean
+}
+
+export function EventShowcase({ events, unavailable = false }: EventShowcaseProps) {
+    return (
+        <section className="py-24 sm:py-32">
+            <div className="container mx-auto px-6">
+                <div className="flex flex-col justify-between gap-6 md:flex-row md:items-end">
+                    <div className="max-w-3xl">
+                        <p className="text-sm font-bold uppercase tracking-[0.18em] text-muted">What’s happening</p>
+                        <h2 className="mt-4 text-5xl font-bold tracking-tight text-ink sm:text-6xl">Upcoming events.</h2>
+                        <p className="mt-5 text-lg leading-8 text-muted">Workshops, meetups, competitions, and community sessions from UISS.</p>
+                    </div>
+                    <Button asChild variant="outline"><Link href="/events">View all events<ArrowRight data-icon="inline-end" /></Link></Button>
+                </div>
+
+                {events.length > 0 ? (
+                    <div className="mt-12 grid gap-5 lg:grid-cols-3">
+                        {events.map((event) => (
+                            <Card key={event.id} className="flex min-h-80 flex-col">
+                                <CardHeader>
+                                    <div className="flex items-center justify-between gap-4">
+                                        <div className="flex size-11 items-center justify-center rounded-lg bg-brand-mark/15 text-brand-mark"><CalendarDays aria-hidden /></div>
+                                        <Badge variant="secondary">{event.registrationStatus.replaceAll('_', ' ')}</Badge>
+                                    </div>
+                                    <p className="mt-5 text-sm font-bold uppercase tracking-[0.14em] text-muted">{event.date}</p>
+                                    <CardTitle className="mt-2 text-2xl"><Link href={event.url} className="hover:underline">{event.title}</Link></CardTitle>
+                                </CardHeader>
+                                <CardContent className="flex-1">
+                                    <p className="leading-7 text-muted">{event.summary || 'Event details are being prepared.'}</p>
+                                    {event.location ? <p className="mt-5 flex items-center gap-2 text-sm font-semibold text-ink"><MapPin className="size-4" aria-hidden />{event.location}</p> : null}
+                                </CardContent>
+                                <CardFooter><Link href={event.url} className="flex items-center gap-2 font-semibold text-ink hover:underline">Event details<ArrowRight aria-hidden /></Link></CardFooter>
+                            </Card>
+                        ))}
+                    </div>
+                ) : (
+                    <div className="mt-12 rounded-lg border border-dashed border-line bg-surface p-10 text-center">
+                        <CalendarDays className="mx-auto size-10 text-muted" aria-hidden />
+                        <h3 className="mt-5 text-2xl font-bold text-ink">No upcoming events have been published.</h3>
+                        <p className="mx-auto mt-3 max-w-xl leading-7 text-muted">{unavailable ? 'Event information could not be loaded right now. Please try again later.' : 'Approved event dates and registration details will appear here when they are available.'}</p>
+                    </div>
+                )}
+            </div>
+        </section>
+    )
+}

--- a/components/projects5.tsx
+++ b/components/projects5.tsx
@@ -1,15 +1,15 @@
 'use client'
 
 import Link from 'next/link'
-import Image from 'next/image'
 import { motion } from 'motion/react'
+import { FolderKanban } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 
 export type ProjectPreview = {
     id: string
     title: string
-    image: string
+    image?: string
     status: string
     type: string
     url: string
@@ -26,6 +26,7 @@ interface Projects5Props {
     heading?: string
     description?: string
     projects?: ProjectPreview[]
+    emptyMessage?: string
 }
 
 const Projects5 = ({
@@ -33,6 +34,7 @@ const Projects5 = ({
     heading = 'Projects',
     description = 'The project catalogue is ready for verified student work. Project details and outcomes will be planned in a later ticket.',
     projects = placeholderProjects,
+    emptyMessage = 'Approved student projects will appear here as they are published by the UISS team.',
 }: Projects5Props) => (
     <section className={cn('py-24 sm:py-32', className)}>
         <div className="container mx-auto px-6">
@@ -41,7 +43,7 @@ const Projects5 = ({
                 <h2 className="mt-4 text-5xl font-bold tracking-tight text-ink sm:text-6xl">{heading}</h2>
                 <p className="mt-5 text-lg leading-8 text-muted">{description}</p>
             </div>
-            <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
+            {projects.length > 0 ? <div className="mt-12 grid grid-cols-1 gap-6 md:grid-cols-2">
                 {projects.map((project, index) => (
                     <motion.article
                         key={project.id}
@@ -52,7 +54,12 @@ const Projects5 = ({
                         className="group overflow-hidden rounded-lg border border-line bg-canvas shadow-soft"
                     >
                         <Link href={project.url} className="block overflow-hidden">
-                            <Image src={project.image} alt="" width={1200} height={800} className="h-72 w-full object-cover grayscale transition duration-500 group-hover:scale-105 group-hover:grayscale-0" />
+                            {project.image ? (
+                                // eslint-disable-next-line @next/next/no-img-element -- administrator-selected media may use any approved host.
+                                <img src={project.image} alt="" className="h-72 w-full object-cover grayscale transition duration-500 group-hover:scale-105 group-hover:grayscale-0" />
+                            ) : (
+                                <span className="flex h-72 w-full items-center justify-center bg-surface text-muted"><FolderKanban className="size-12" aria-hidden /></span>
+                            )}
                         </Link>
                         <div className="flex items-center justify-between gap-5 p-5">
                             <div>
@@ -63,7 +70,13 @@ const Projects5 = ({
                         </div>
                     </motion.article>
                 ))}
-            </div>
+            </div> : (
+                <div className="mt-12 rounded-lg border border-dashed border-line bg-surface p-10 text-center">
+                    <FolderKanban className="mx-auto size-10 text-muted" aria-hidden />
+                    <h3 className="mt-5 text-2xl font-bold text-ink">Projects are being prepared.</h3>
+                    <p className="mx-auto mt-3 max-w-xl leading-7 text-muted">{emptyMessage}</p>
+                </div>
+            )}
         </div>
     </section>
 )

--- a/components/team1.tsx
+++ b/components/team1.tsx
@@ -20,6 +20,7 @@ interface Team1Props {
     description?: string
     members?: TeamMember[]
     className?: string
+    emptyMessage?: string
 }
 
 const Team1 = ({
@@ -27,6 +28,7 @@ const Team1 = ({
     description = 'The structure is ready for the approved names, positions, portraits, and biographies.',
     members = placeholderMembers,
     className,
+    emptyMessage = 'Approved leadership profiles will appear here once they have been added by the UISS team.',
 }: Team1Props) => (
     <section id="team" className={cn('py-24 sm:py-32', className)}>
         <div className="container mx-auto px-6">
@@ -35,7 +37,7 @@ const Team1 = ({
                 <h2 className="mt-4 text-balance text-4xl font-bold tracking-tight text-ink sm:text-5xl">{heading}</h2>
                 <p className="mt-5 text-lg leading-8 text-muted">{description}</p>
             </div>
-            <Carousel className="mt-14" opts={{ align: 'start' }} aria-label="UISS leaders">
+            {members.length > 0 ? <Carousel className="mt-14" opts={{ align: 'start' }} aria-label="UISS leaders">
                 <CarouselContent>
                     {members.map((member) => (
                         <CarouselItem key={member.id} className="sm:basis-1/2 lg:basis-1/3 xl:basis-1/4">
@@ -54,7 +56,12 @@ const Team1 = ({
                     <CarouselPrevious className="static translate-y-0" />
                     <CarouselNext className="static translate-y-0" />
                 </div>
-            </Carousel>
+            </Carousel> : (
+                <div className="mt-14 rounded-lg border border-dashed border-line bg-surface p-10 text-center">
+                    <h3 className="text-2xl font-bold text-ink">Leadership profiles are being prepared.</h3>
+                    <p className="mx-auto mt-3 max-w-xl leading-7 text-muted">{emptyMessage}</p>
+                </div>
+            )}
         </div>
     </section>
 )

--- a/lib/homepage-data.ts
+++ b/lib/homepage-data.ts
@@ -1,0 +1,86 @@
+import 'server-only'
+
+import { asc, desc, eq, gte } from 'drizzle-orm'
+import { db } from '@/app/db'
+import { clubs, events, heroPage, leaders, projects } from '@/app/db/schema'
+import { listZenblogPosts } from '@/lib/zenblog'
+
+type QueryResult<T> = {
+    data: T
+    unavailable: boolean
+}
+
+async function safely<T>(label: string, query: Promise<T>, fallback: T): Promise<QueryResult<T>> {
+    try {
+        return { data: await query, unavailable: false }
+    } catch (error) {
+        console.warn(`[UISS homepage] ${label} could not be loaded.`, error)
+        return { data: fallback, unavailable: true }
+    }
+}
+
+export async function getHomepageData() {
+    const now = new Date()
+
+    const [hero, activeClubs, upcomingEvents, publishedProjects, leadership, blog] = await Promise.all([
+        safely(
+            'Hero content',
+            db.query.heroPage.findFirst({ where: eq(heroPage.section, 'homepage') }),
+            undefined,
+        ),
+        safely(
+            'Clubs',
+            db.query.clubs.findMany({
+                where: eq(clubs.status, 'active'),
+                orderBy: [asc(clubs.title)],
+                limit: 4,
+                with: { coverMedia: true },
+            }),
+            [],
+        ),
+        safely(
+            'Events',
+            db.query.events.findMany({
+                where: gte(events.startsAt, now),
+                orderBy: [asc(events.startsAt)],
+                limit: 3,
+                with: { coverMedia: true },
+            }),
+            [],
+        ),
+        safely(
+            'Projects',
+            db.query.projects.findMany({
+                where: eq(projects.publicationStatus, 'published'),
+                orderBy: [desc(projects.year), desc(projects.createdAt)],
+                limit: 4,
+                with: { coverMedia: true },
+            }),
+            [],
+        ),
+        safely(
+            'Leadership',
+            db.query.leaders.findMany({
+                orderBy: [desc(leaders.year), asc(leaders.lastName), asc(leaders.firstName)],
+                limit: 50,
+                with: { position: true },
+            }),
+            [],
+        ),
+        listZenblogPosts(),
+    ])
+
+    const latestLeadershipYear = leadership.data.at(0)?.year
+    const currentLeaders = latestLeadershipYear
+        ? leadership.data.filter((leader) => leader.year === latestLeadershipYear).slice(0, 11)
+        : []
+
+    return {
+        hero,
+        clubs: activeClubs,
+        events: upcomingEvents,
+        projects: publishedProjects,
+        leaders: { data: currentLeaders, unavailable: leadership.unavailable },
+        blog,
+    }
+}


### PR DESCRIPTION
## Summary
- replace the legacy homepage with the approved UISS design-system sections
- load hero, clubs, events, published projects, and current leaders directly from Supabase with resilient empty states
- surface the latest Zenblog articles and keep the one-hour refresh interval
- add a responsive mobile navigation menu for Clubs, Blog, Events, Projects, and membership
- bound Postgres connection waits so content failures do not take down the public page

## Verification
- `bunx tsc --noEmit`
- `bun run lint` (passes with existing legacy warnings)
- `bun run build`
- desktop and mobile browser review, including the mobile menu
- verified the connected Supabase project is healthy and the public launch-content tables are currently empty

Closes #62
Related to #60